### PR TITLE
Add sails-generate-views-jade dependencies.

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "sails-generate-controller": "~0.10.0",
     "sails-generate-views": "~0.10.0",
     "sails-generate-adapter": "~0.10.0",
-    "sails-generate-generator": "~0.10.0"
+    "sails-generate-generator": "~0.10.0",
+    "sails-generate-views-jade": "~0.10.0"
   },
   "devDependencies": {
     "mocha": "~1.17.0",


### PR DESCRIPTION
Missing sails-generate-views-jade dependencies.

It will cause error when perform `sails new appname --template=jade`

[sails new appname --template=jade cause Generator Error ‧ Issue #1524 ‧ balderdashy/sails](https://github.com/balderdashy/sails/issues/1524#issuecomment-37995812)
