### PR TITLE
Add 'pre' target

### DIFF
--- a/lib/target.js
+++ b/lib/target.js
@@ -87,6 +87,15 @@ function generateTarget(options, cb) {
         }
         return JSONFileHelper(scope, sb);
       }
+      if (target.pre) {
+
+        var preTargetCb = function(err, tar) {
+          if (err) return sb(err);
+          return recursiveGenerate(tar, scope, sb);
+        };
+
+        return target.pre(scope, preTargetCb);
+      }
 
       // If we made it here, this must be a recursive generator:
 


### PR DESCRIPTION
Similar to _exec_ but the value provided to the callback is processed as a target.
