### PR TITLE
Let `jsonfile` helper accept function as `data` property

### DIFF
--- a/lib/target.js
+++ b/lib/target.js
@@ -79,6 +79,9 @@ function generateTarget(options, cb) {
       }
       if (target.jsonfile) {
         if (typeof target.jsonfile === 'object') {
+          if (typeof target.jsonfile.data === 'function') {
+            jsonfile.data = target.jsonfile.data(scope);
+          }
           scope = mergeSubtargetScope(scope, target.jsonfile);
         } else if (typeof target.jsonfile === 'function') {
           scope = _.merge(scope, {

--- a/test/unit/generate.jsonfile.test.js
+++ b/test/unit/generate.jsonfile.test.js
@@ -52,10 +52,22 @@ describe('jsonfile generator', function () {
 	});
 
 
+  describe('with `data` specified as function', function() {
+    before(function () {
+      this.options = {
+        rootPath: this.heap.alloc(),
+        data: function() {
+          return {foo: 'bar'};
+        }
+      }
+    });
+
+    it('should trigger `success`', expect('success'));
+    it('should put function result into file', assert.fileIsExactly('{"foo":"bar"}'));
+  });
 
 
-
-	describe('if file already exists', function () {
+  describe('if file already exists', function () {
 
 		before(function (cb) {
 			this.options = {


### PR DESCRIPTION
This currently works (i.e. executes the function)

``` javascript
targets: {
  './package.json': {
    jsonfile: function(scope) { return jsonBasedOnScope; }
  },
}
```

…and this doesn't (i.e. doesn't execute the function and places `undefined` in the file):

``` javascript
targets: {
  './package.json': {
    jsonfile: {
      data: function(scope) { return jsonBasedOnScope; },
      force: true
    }
  },
}
```

…which is a bit inconsistent, and also inconvenient in my particular case. I need to augment existing package.json with custom dependencies.

This PR adds support for the second scenario.
