### PR TITLE
Ability to add `scope.packageJson` object to initial `scope` 

### DIFF
--- a/lib/generate.js
+++ b/lib/generate.js
@@ -79,7 +79,7 @@ function generate(Generator, scope, cb) {
       sb.log.verbose('Generating ' + util.inspect(Generator) + ' at ' + scope.rootPath + '...');
 
       // Process all of the generator's targets concurrently
-      async.each(Object.keys(Generator.targets), function(keyPath, async_each_cb) {
+      async.eachSeries(Object.keys(Generator.targets), function(keyPath, async_each_cb) {
           var async_each_sb = reportback.extend(async_each_cb);
 
 
@@ -134,8 +134,6 @@ function generate(Generator, scope, cb) {
             keyPath: keyPath
           });
 
-
-
           // If `target` is an array, run each item
           if (_.isArray(target)) {
             async.eachSeries(target, function(targetItem, async_eachSeries_cb) {
@@ -143,11 +141,23 @@ function generate(Generator, scope, cb) {
               generateTarget({
                 target: targetItem,
                 parent: Generator,
-                scope: _.cloneDeep(targetScope),
+                // scope: _.cloneDeep(targetScope),
+                scope: targetScope,
                 recursiveGenerate: generate
               }, async_eachSeries_cb);
 
-            }, async_each_sb);
+            }, function(err) {
+              // Have to merge `packageJson` object because
+              // `targetScope` don't allow to mutate initial `scope`
+              if (targetScope.packageJson) {
+                if (!scope.packageJson) {
+                  scope.packageJson = {};
+                }
+                _.merge(scope.packageJson, targetScope.packageJson)
+              }
+              // invoke callback
+              async_each_sb(err);
+            });
             return;
           }
 
@@ -162,7 +172,6 @@ function generate(Generator, scope, cb) {
         }, // </async.each.iterator>
 
         function done(err) {
-
           // Expose a `error` handler in generators
           if (err) {
             var errorFn = Generator.error || function defaultError(err, scope, _cb) {


### PR DESCRIPTION
PR will add an ability to add `scope.packageJson` object to initial `scope` object. that will mutate `package.json` file on generation of new project [here](https://github.com/balderdashy/sails-generate-new/blob/master/json/package.json.js#L78)
