### PR TITLE
Fix path to generated assets

### DIFF
--- a/lib/core-generators/new/index.js
+++ b/lib/core-generators/new/index.js
@@ -181,24 +181,24 @@ module.exports = {
               overridable: 'assets',
               generator: {
                 targets: {
-                  './assets':                       { folder: {} },
-                  './assets/favicon.ico':           { copy: 'assets/favicon.ico' },
-                  './assets/robots.txt':            { template: 'assets/robots.txt' },
+                  '.':                       { folder: {} },
+                  './favicon.ico':           { copy: 'assets/favicon.ico' },
+                  './robots.txt':            { template: 'assets/robots.txt' },
 
-                  './assets/images':                { folder: {} },
-                  './assets/images/.gitkeep':       { copy: '../../../shared-templates/gitkeep.template' },
+                  './images':                { folder: {} },
+                  './images/.gitkeep':       { copy: '../../../shared-templates/gitkeep.template' },
 
-                  './assets/styles':                { folder: {} },
-                  './assets/styles/importer.less':  { template: 'assets/styles/importer.less' },
+                  './styles':                { folder: {} },
+                  './styles/importer.less':  { template: 'assets/styles/importer.less' },
 
-                  './assets/templates':             { folder: {} },
-                  './assets/templates/.gitkeep':    { copy: '../../../shared-templates/gitkeep.template' },
+                  './templates':             { folder: {} },
+                  './templates/.gitkeep':    { copy: '../../../shared-templates/gitkeep.template' },
 
-                  './assets/js':                    { folder: {} },
-                  './assets/js/.gitkeep':           { copy: '../../../shared-templates/gitkeep.template' },
+                  './js':                    { folder: {} },
+                  './js/.gitkeep':           { copy: '../../../shared-templates/gitkeep.template' },
 
-                  './assets/dependencies':          { folder: {} },
-                  './assets/dependencies/.gitkeep': { copy: '../../../shared-templates/gitkeep.template' },
+                  './dependencies':          { folder: {} },
+                  './dependencies/.gitkeep': { copy: '../../../shared-templates/gitkeep.template' },
 
 
                   //  ███████╗ █████╗ ██╗██╗     ███████╗   ██╗ ██████╗         ██╗███████╗
@@ -229,7 +229,7 @@ module.exports = {
                         // (because it goes up one too many dirs).  This could be related to the issue w/ the skipAssets
                         // tests in Sails...
                         targets: {
-                          './assets/dependencies/sails.io.js': { template: 'sails.io.js' }
+                          './dependencies/sails.io.js': { template: 'sails.io.js' }
                         }//</targets>
                       }//</generator>
                     }//</sails.io.js>


### PR DESCRIPTION
https://github.com/balderdashy/sails-generate/commit/8c3c91c5a03954b9c5597e6bb724614c364204a9 made `./assets` its own overridable generator, so everything beneath it needs to be relative to `./assets`.  Otherwise generated apps end up with `assets/assets` folders.