### PR TITLE
Adds "classic" (req, res) templates for Easter Egg actions

### DIFF
--- a/lib/core-generators/action/index.js
+++ b/lib/core-generators/action/index.js
@@ -25,8 +25,18 @@ module.exports = {
   //  ╚═╝╚═╝╚  ╚═╝╩╚═╚═╝ooo
   before: function (scope, done){
 
+    var self = this;
 
     var roughName;
+
+    // Set up the default suffix for easter-egg actions.
+    var altTemplateSuffix = '-action.template';
+
+    // If `--actions2` was used, switch the default template and easter-egg template suffix.
+    if (scope.actions2) {
+      self.targets['./api/controllers/:relPath'] = { template: 'actions2.template' };
+      altTemplateSuffix = '-actions2.template';
+    }
 
     // Accept --name
     if (scope.name) {
@@ -95,6 +105,7 @@ module.exports = {
 
     // Grab the filename for potential use in our template.
     scope.filename = path.basename(scope.relPath);
+
 
     // Identify the action "stem" for use below.
     // (e.g. "view-stuff-and-things" from "v1.pages.view-stuff-and-things")
@@ -173,11 +184,7 @@ module.exports = {
       console.log('| generated action isn\'t a drop-in solution.  The goal is to help you get ');
       console.log('| off the ground running the right way, using recommended best practices.');
       console.log('| (And... well, the time you save up front is a nice bonus.)');
-      scope.getAlternativeTemplate = function (){
-        var jsTpl = fsx.readFileSync(path.resolve(__dirname, 'templates', stem+'-action.template'), 'utf8');
-        var renderedJs = _.template(jsTpl)(scope);
-        return renderedJs;
-      };
+      self.targets['./api/controllers/:relPath'] = { template: stem + altTemplateSuffix };
     }//‡
     //
     // ACTION THAT PROCESSES A LOGIN FORM
@@ -186,11 +193,7 @@ module.exports = {
     // (get started with a boilerplate handler for a login form)
     else if (stem === 'login') {
       console.log('* * *   Using built-in `login` boilerplate...   * * *');
-      scope.getAlternativeTemplate = function (){
-        var jsTpl = fsx.readFileSync(path.resolve(__dirname, 'templates', stem+'-action.template'), 'utf8');
-        var renderedJs = _.template(jsTpl)(scope);
-        return renderedJs;
-      };
+      self.targets['./api/controllers/:relPath'] = { template: stem + altTemplateSuffix };
     }//‡
     //
     // ACTION THAT PROCESSES A LOGOUT
@@ -199,11 +202,7 @@ module.exports = {
     // (get started with a boilerplate action that processes a logout)
     else if (stem === 'logout') {
       console.log('* * *   Using built-in `logout` boilerplate...   * * *');
-      scope.getAlternativeTemplate = function (){
-        var jsTpl = fsx.readFileSync(path.resolve(__dirname, 'templates', stem+'-action.template'), 'utf8');
-        var renderedJs = _.template(jsTpl)(scope);
-        return renderedJs;
-      };
+      self.targets['./api/controllers/:relPath'] = { template: stem + altTemplateSuffix };
     }//‡
     //
     // ACTION THAT PROCESSES A CONTACT FORM
@@ -212,11 +211,7 @@ module.exports = {
     // (get started with a boilerplate handler for a contact form)
     else if (stem === 'contact') {
       console.log('* * *   Using built-in `contact` boilerplate...   * * *');
-      scope.getAlternativeTemplate = function (){
-        var jsTpl = fsx.readFileSync(path.resolve(__dirname, 'templates', stem+'-action.template'), 'utf8');
-        var renderedJs = _.template(jsTpl)(scope);
-        return renderedJs;
-      };
+      self.targets['./api/controllers/:relPath'] = { template: stem + altTemplateSuffix };
     }//‡
     //
     // ACTION THAT PROCESSES A PASSWORD RECOVERY REQUEST
@@ -256,7 +251,7 @@ module.exports = {
   //   ╩ ╩ ╩╩╚═╚═╝╚═╝ ╩ ╚═╝
   targets: {
 
-    './api/controllers/:relPath': { template: 'actions2-action.template' }
+    './api/controllers/:relPath': { template: 'action.template' }
 
   },
 

--- a/lib/core-generators/action/index.js
+++ b/lib/core-generators/action/index.js
@@ -5,7 +5,7 @@
 var path = require('path');
 var _ = require('lodash');
 var fsx = require('fs-extra');
-
+var builtinTemplate = require('../../builtins/template');
 
 
 /**
@@ -29,12 +29,15 @@ module.exports = {
 
     var roughName;
 
+    // The default template to use.
+    scope.templateName = 'action.template';
+
     // Set up the default suffix for easter-egg actions.
     var altTemplateSuffix = '-action.template';
 
     // If `--actions2` was used, switch the default template and easter-egg template suffix.
     if (scope.actions2) {
-      self.targets['./api/controllers/:relPath'] = { template: 'actions2.template' };
+      scope.templateName = 'actions2.template';
       altTemplateSuffix = '-actions2.template';
     }
 
@@ -184,7 +187,7 @@ module.exports = {
       console.log('| generated action isn\'t a drop-in solution.  The goal is to help you get ');
       console.log('| off the ground running the right way, using recommended best practices.');
       console.log('| (And... well, the time you save up front is a nice bonus.)');
-      self.targets['./api/controllers/:relPath'] = { template: stem + altTemplateSuffix };
+      scope.templateName = stem + altTemplateSuffix;
     }//‡
     //
     // ACTION THAT PROCESSES A LOGIN FORM
@@ -193,7 +196,7 @@ module.exports = {
     // (get started with a boilerplate handler for a login form)
     else if (stem === 'login') {
       console.log('* * *   Using built-in `login` boilerplate...   * * *');
-      self.targets['./api/controllers/:relPath'] = { template: stem + altTemplateSuffix };
+      scope.templateName = stem + altTemplateSuffix;
     }//‡
     //
     // ACTION THAT PROCESSES A LOGOUT
@@ -202,7 +205,7 @@ module.exports = {
     // (get started with a boilerplate action that processes a logout)
     else if (stem === 'logout') {
       console.log('* * *   Using built-in `logout` boilerplate...   * * *');
-      self.targets['./api/controllers/:relPath'] = { template: stem + altTemplateSuffix };
+      scope.templateName = stem + altTemplateSuffix;
     }//‡
     //
     // ACTION THAT PROCESSES A CONTACT FORM
@@ -211,7 +214,7 @@ module.exports = {
     // (get started with a boilerplate handler for a contact form)
     else if (stem === 'contact') {
       console.log('* * *   Using built-in `contact` boilerplate...   * * *');
-      self.targets['./api/controllers/:relPath'] = { template: stem + altTemplateSuffix };
+      scope.templateName = stem + altTemplateSuffix;
     }//‡
     //
     // ACTION THAT PROCESSES A PASSWORD RECOVERY REQUEST
@@ -251,7 +254,17 @@ module.exports = {
   //   ╩ ╩ ╩╩╚═╚═╝╚═╝ ╩ ╚═╝
   targets: {
 
-    './api/controllers/:relPath': { template: 'action.template' }
+    './api/controllers/:relPath': {
+      exec: function(scope, done) {
+        scope.templatePath = './' + scope.templateName;
+        builtinTemplate(scope, function(err) {
+          if (err) {
+            return done(err);
+          }
+          return done();
+        });
+      }
+    }
 
   },
 

--- a/lib/core-generators/action/templates/action.template
+++ b/lib/core-generators/action/templates/action.template
@@ -1,0 +1,13 @@
+<% if (verbose) { %>/**
+ * <%= relPath %>
+ *
+ * @description :: Server-side controller action for handling incoming requests.
+ * @help        :: See http://sailsjs.com/docs/concepts/actions-and-controllers
+ */
+<% } %>module.exports = function (req, res) {
+<% if (inferredViewTemplatePath) { %>
+  return res.view(<%= util.inspect(inferredViewTemplatePath) %>);
+<% } else { %>
+  return res.ok();
+<% } %>
+};

--- a/lib/core-generators/action/templates/actions2.template
+++ b/lib/core-generators/action/templates/actions2.template
@@ -1,15 +1,8 @@
-<%
-  // If a getter function was provided, then call that to get our template instead.
-  if (getAlternativeTemplate) {
-    %><%= getAlternativeTemplate() %><%
-  }
-  // Otherwise just use the normal template.
-  else {
-    %><%if (verbose) { %>/**
+<%if (verbose) { %>/**
  * <%= relPath %>
  *
  * @description :: Server-side controller action for handling incoming requests.
- * @help        :: See http://sailsjs.com/docs/concepts/controllers
+ * @help        :: See http://sailsjs.com/docs/concepts/actions-and-controllers
  */
 <% } %>module.exports = {
 
@@ -79,4 +72,3 @@ if (verbose) { %>
 
 
 };
-<% } %>

--- a/lib/core-generators/action/templates/contact-action.template
+++ b/lib/core-generators/action/templates/contact-action.template
@@ -1,110 +1,72 @@
-module.exports = {
+/**
+ * Module dependencies
+ */
+var stdlib = require('sails-stdlib');
+
+module.exports = function (req, res) {
+
+  var humanName = req.param('humanName');
+  var message = req.param('message');
+  var emailAddress = req.param('emailAddress');
+  var topic = req.param('topic');
+
+  if (!humanName) { return res.badRequest(new Error('Missing `humanName` param')); }
+  if (!message) { return res.badRequest(new Error('Missing `message` param')); }
+  if (!emailAddress) { return res.badRequest(new Error('Missing `emailAddress` param')); }
+  if (!topic) { return res.badRequest(new Error('Missing `topic` param')); }
 
 
-  friendlyName: 'Contact',
+  // Build a summary string for the incoming message.
+  var messageSummary =
+  'From: ' + humanName + ' <' + emailAddress + '>\n\n' +
+  'Topic: ' + topic + '\n\n' +
+  'Message: \n\n' + message;
 
 
-  description: 'Send a message from the contact form.',
+  // Check that an internal recipient email address is configured,
+  // and that all required Mailgun credentials are set up.
+  if (!sails.config.custom.internalEmail || !sails.config.custom.mailgunApiKey || !sails.config.custom.mailgunApiDomain) {
 
-
-  inputs: {
-
-    emailAddress: {
-      description: 'A return email address where we can respond, e.g. "hermione@hogwarts.edu".',
-      type: 'string',
-      required: true
-    },
-
-    topic: {
-      description: 'The topic chosen from the contact form dropdown, e.g. "I want to buy stuff".',
-      type: 'string',
-      required: true
-    },
-
-    humanName: {
-      description: 'The full name of the human sending this message, e.g. "Hermione Granger".',
-      type: 'string',
-      required: true
-    },
-
-    message: {
-      description: 'The custom message, in plain text.',
-      type: 'string',
-      required: true
-    },
-
-  },
-
-
-  exits: {
-
-    success: {
-      description: 'The message was sent successfully.'
+    var errMsg = 'Cannot deliver incoming message from contact form because:\n';
+    if (!sails.config.custom.internalEmail) {
+      errMsg += ' • there is no internal email address configured for this app (`sails.config.custom.internalEmail`)\n';
+    }
+    if (!sails.config.custom.mailgunApiKey) {
+      errMsg += ' • a required Mailgun credential is missing from this app\'s configuration (`sails.config.custom.mailgunApiKey`)\n';
+    }
+    if (!sails.config.custom.mailgunApiDomain) {
+      errMsg += ' • a required Mailgun credential is missing from this app\'s configuration (`sails.config.custom.mailgunApiDomain`)\n';
     }
 
-  },
-
-
-  fn: function(inputs, exits, env) {
-
-    // Import dependencies
-    var stdlib = require('sails-stdlib');
-
-    // Build a summary string for the incoming message.
-    var messageSummary =
-    'From: ' + inputs.humanName + ' <' + inputs.emailAddress + '>\n\n' +
-    'Topic: ' + inputs.topic + '\n\n' +
-    'Message: \n\n' + inputs.message;
-
-
-    // Check that an internal recipient email address is configured,
-    // and that all required Mailgun credentials are set up.
-    if (!sails.config.custom.internalEmail || !sails.config.custom.mailgunApiKey || !sails.config.custom.mailgunApiDomain) {
-
-      var errMsg = 'Cannot deliver incoming message from contact form because:\n';
-      if (!sails.config.custom.internalEmail) {
-        errMsg += ' • there is no internal email address configured for this app (`sails.config.custom.internalEmail`)\n';
-      }
-      if (!sails.config.custom.mailgunApiKey) {
-        errMsg += ' • a required Mailgun credential is missing from this app\'s configuration (`sails.config.custom.mailgunApiKey`)\n';
-      }
-      if (!sails.config.custom.mailgunApiDomain) {
-        errMsg += ' • a required Mailgun credential is missing from this app\'s configuration (`sails.config.custom.mailgunApiDomain`)\n';
-      }
-
-      errMsg += '\n'+
-      'Here is a summary of the incoming correspondence, just so we at least have it in our logs:\n'+
-      '------------------\n'+
-      messageSummary+'\n'+
-      '------------------';
-      return exits.error(new Error(errMsg));
-    }
-    // --•
-
-
-    //  ╔═╗╔═╗╔╗╔╔╦╗  ┌─┐┌─┐┌┐┌┌┬┐┌─┐┌─┐┌┬┐  ┌─┐┌┬┐┌─┐┬┬
-    //  ╚═╗║╣ ║║║ ║║  │  │ ││││ │ ├─┤│   │   ├┤ │││├─┤││
-    //  ╚═╝╚═╝╝╚╝═╩╝  └─┘└─┘┘└┘ ┴ ┴ ┴└─┘ ┴   └─┘┴ ┴┴ ┴┴┴─┘
-    stdlib('mailgun').sendPlaintextEmail({
-      apiKey: sails.config.custom.mailgunApiKey,
-      domain: sails.config.custom.mailgunDomain,
-      toName: 'Internal contact',
-      toEmail: sails.config.custom.internalEmail,
-      subject: 'New message from contact form',
-      message: messageSummary,
-      fromName: 'Sailsbot',
-      fromEmail: 'noreply@example.com'
-    }).exec({
-      error: function(err) {
-        return exits.error(err);
-      },
-      success: function() {
-        return exits.success();
-      }
-    }); // </ stdlib('mailgun').sendPlaintextEmail().exec() />
-
+    errMsg += '\n'+
+    'Here is a summary of the incoming correspondence, just so we at least have it in our logs:\n'+
+    '------------------\n'+
+    messageSummary+'\n'+
+    '------------------';
+    return res.serverError(new Error(errMsg));
   }
+  // --•
 
 
-};
+  //  ╔═╗╔═╗╔╗╔╔╦╗  ┌─┐┌─┐┌┐┌┌┬┐┌─┐┌─┐┌┬┐  ┌─┐┌┬┐┌─┐┬┬
+  //  ╚═╗║╣ ║║║ ║║  │  │ ││││ │ ├─┤│   │   ├┤ │││├─┤││
+  //  ╚═╝╚═╝╝╚╝═╩╝  └─┘└─┘┘└┘ ┴ ┴ ┴└─┘ ┴   └─┘┴ ┴┴ ┴┴┴─┘
+  stdlib('mailgun').sendPlaintextEmail({
+    apiKey: sails.config.custom.mailgunApiKey,
+    domain: sails.config.custom.mailgunDomain,
+    toName: 'Internal contact',
+    toEmail: sails.config.custom.internalEmail,
+    subject: 'New message from contact form',
+    message: messageSummary,
+    fromName: 'Sailsbot',
+    fromEmail: 'noreply@example.com'
+  }).exec({
+    error: function(err) {
+      return res.serverError(err);
+    },
+    success: function() {
+      return res.ok();
+    }
+  }); // </ stdlib('mailgun').sendPlaintextEmail().exec() />
 
+}

--- a/lib/core-generators/action/templates/contact-action.template
+++ b/lib/core-generators/action/templates/contact-action.template
@@ -69,4 +69,4 @@ module.exports = function (req, res) {
     }
   }); // </ stdlib('mailgun').sendPlaintextEmail().exec() />
 
-}
+};

--- a/lib/core-generators/action/templates/contact-actions2.template
+++ b/lib/core-generators/action/templates/contact-actions2.template
@@ -1,0 +1,110 @@
+module.exports = {
+
+
+  friendlyName: 'Contact',
+
+
+  description: 'Send a message from the contact form.',
+
+
+  inputs: {
+
+    emailAddress: {
+      description: 'A return email address where we can respond, e.g. "hermione@hogwarts.edu".',
+      type: 'string',
+      required: true
+    },
+
+    topic: {
+      description: 'The topic chosen from the contact form dropdown, e.g. "I want to buy stuff".',
+      type: 'string',
+      required: true
+    },
+
+    humanName: {
+      description: 'The full name of the human sending this message, e.g. "Hermione Granger".',
+      type: 'string',
+      required: true
+    },
+
+    message: {
+      description: 'The custom message, in plain text.',
+      type: 'string',
+      required: true
+    },
+
+  },
+
+
+  exits: {
+
+    success: {
+      description: 'The message was sent successfully.'
+    }
+
+  },
+
+
+  fn: function(inputs, exits, env) {
+
+    // Import dependencies
+    var stdlib = require('sails-stdlib');
+
+    // Build a summary string for the incoming message.
+    var messageSummary =
+    'From: ' + inputs.humanName + ' <' + inputs.emailAddress + '>\n\n' +
+    'Topic: ' + inputs.topic + '\n\n' +
+    'Message: \n\n' + inputs.message;
+
+
+    // Check that an internal recipient email address is configured,
+    // and that all required Mailgun credentials are set up.
+    if (!sails.config.custom.internalEmail || !sails.config.custom.mailgunApiKey || !sails.config.custom.mailgunApiDomain) {
+
+      var errMsg = 'Cannot deliver incoming message from contact form because:\n';
+      if (!sails.config.custom.internalEmail) {
+        errMsg += ' • there is no internal email address configured for this app (`sails.config.custom.internalEmail`)\n';
+      }
+      if (!sails.config.custom.mailgunApiKey) {
+        errMsg += ' • a required Mailgun credential is missing from this app\'s configuration (`sails.config.custom.mailgunApiKey`)\n';
+      }
+      if (!sails.config.custom.mailgunApiDomain) {
+        errMsg += ' • a required Mailgun credential is missing from this app\'s configuration (`sails.config.custom.mailgunApiDomain`)\n';
+      }
+
+      errMsg += '\n'+
+      'Here is a summary of the incoming correspondence, just so we at least have it in our logs:\n'+
+      '------------------\n'+
+      messageSummary+'\n'+
+      '------------------';
+      return exits.error(new Error(errMsg));
+    }
+    // --•
+
+
+    //  ╔═╗╔═╗╔╗╔╔╦╗  ┌─┐┌─┐┌┐┌┌┬┐┌─┐┌─┐┌┬┐  ┌─┐┌┬┐┌─┐┬┬
+    //  ╚═╗║╣ ║║║ ║║  │  │ ││││ │ ├─┤│   │   ├┤ │││├─┤││
+    //  ╚═╝╚═╝╝╚╝═╩╝  └─┘└─┘┘└┘ ┴ ┴ ┴└─┘ ┴   └─┘┴ ┴┴ ┴┴┴─┘
+    stdlib('mailgun').sendPlaintextEmail({
+      apiKey: sails.config.custom.mailgunApiKey,
+      domain: sails.config.custom.mailgunDomain,
+      toName: 'Internal contact',
+      toEmail: sails.config.custom.internalEmail,
+      subject: 'New message from contact form',
+      message: messageSummary,
+      fromName: 'Sailsbot',
+      fromEmail: 'noreply@example.com'
+    }).exec({
+      error: function(err) {
+        return exits.error(err);
+      },
+      success: function() {
+        return exits.success();
+      }
+    }); // </ stdlib('mailgun').sendPlaintextEmail().exec() />
+
+  }
+
+
+};
+

--- a/lib/core-generators/action/templates/login-action.template
+++ b/lib/core-generators/action/templates/login-action.template
@@ -68,4 +68,4 @@ module.exports = function (req, res) {
     });//</checkPassword().exec()>
   });//</User.find().exec()>
 
-}
+};

--- a/lib/core-generators/action/templates/login-action.template
+++ b/lib/core-generators/action/templates/login-action.template
@@ -1,124 +1,71 @@
-module.exports = {
+/**
+ * Module dependencies
+ */
+var stdlib = require('sails-stdlib');
+
+module.exports = function (req, res) {
+
+  var usernameOrEmail = req.param('usernameOrEmail');
+  var password = req.param('password');
+
+  if (!usernameOrEmail) { return res.badRequest(new Error('Missing `usernameOrEmail` param')); }
+  if (!password) { return res.badRequest(new Error('Missing `password` param')); }
 
 
-  friendlyName: 'Login',
-
-
-  description: 'Log in using the provided username/email and password combination.',
-
-
-  extendedDescription:
-  'This action attempts to look up the user record in the database with the '+
-  'specified username (or email address).  Then, if such a user exists, it uses '+
-  'bcrypt to compare the hashed password from the database with the provided password '+
-  'attempt.',
-
-
-  inputs: {
-
-    usernameOrEmail: {
-      description: 'The username or email to try in this attempt, e.g. "particlebanana".',
-      type: 'string',
-      required: true
-    },
-
-    password: {
-      description: 'The unencrypted password to try in this attempt, e.g. "passwordlol".',
-      type: 'string',
-      required: true
+  //  ╔═╗╦╔╗╔╔╦╗  ┬ ┬┌─┐┌─┐┬─┐
+  //  ╠╣ ║║║║ ║║  │ │└─┐├┤ ├┬┘
+  //  ╚  ╩╝╚╝═╩╝  └─┘└─┘└─┘┴└─
+  // Look up by either username or email address.
+  User.findOne({
+    or: [
+      {
+        emailAddress: usernameOrEmail
+      },
+      {
+        username: usernameOrEmail
+      }
+    ]
+  })
+  .exec(function(err, userRecord) {
+    if(err) {
+      return res.serverError(err);
     }
 
-  },
-
-
-  exits: {
-
-    success: {
-      description: 'The requesting user agent has been successfully logged in.',
-      extendedDescription:
-      'Under the covers, this stores the id of the logged-in user in the session '+
-      'under the `userId` key.  The next time this user agent sends a request, assuming '+
-      'it includes a cookie (like a web browser), Sails will automatically make this '+
-      'user id available as `req.session.userId` in the corresponding action.'
-    },
-
-    notFound: {
-      description: 'The provided username/email and password combination does not '+
-      'match any user in the database.',
-      responseType: 'notFound'<% if (verbose) { %>,
-      // This uses the `notFound` response located in `api/responses/notFound.js`.
-      // To customize the generic "notFound" response across this entire app, change that file
-      // (see http://sailsjs.com/anatomy/api/responses/not-found-js).
-      //
-      // To customize the response for _only this_ action, replace `responseType` with `statusCode: 404`
-      // and change the implementation below accordingly (see http://sailsjs.com/docs/concepts/controllers).<% } %>
+    // If there was no user, exit thru "notFound".
+    if(!userRecord) {
+      return res.notFound();
     }
 
-  },
 
+    //  ╔═╗╦ ╦╔═╗╔═╗╦╔═  ┌─┐┌─┐┌─┐┌─┐┬ ┬┌─┐┬─┐┌┬┐
+    //  ║  ╠═╣║╣ ║  ╠╩╗  ├─┘├─┤└─┐└─┐││││ │├┬┘ ││
+    //  ╚═╝╩ ╩╚═╝╚═╝╩ ╩  ┴  ┴ ┴└─┘└─┘└┴┘└─┘┴└──┴┘
+    stdlib('passwords').checkPassword({
+      passwordAttempt: password,
+      encryptedPassword: userRecord.password
+    }).exec({
+      error: function(err) {
+        return res.serverError(err);
+      },
+      incorrect: function () {
+        // If the password doesn't match, then also
+        // exit thru "notFound" to prevent sniffing.
+        return res.notFound();
+      },
+      success: function (){
 
-  fn: function (inputs, exits, env) {
+        //  ╦  ╔═╗╔═╗╦╔╗╔
+        //  ║  ║ ║║ ╦║║║║
+        //  ╩═╝╚═╝╚═╝╩╝╚╝
+        req.session.userId = userRecord.id;
 
-    // Import dependencies
-    var stdlib = require('sails-stdlib');
+        //  ╦═╗╔═╗╔╦╗╦ ╦╦═╗╔╗╔  ┬─┐┌─┐┌─┐┌─┐┌─┐┌┐┌┌─┐┌─┐
+        //  ╠╦╝║╣  ║ ║ ║╠╦╝║║║  ├┬┘├┤ └─┐├─┘│ ││││└─┐├┤
+        //  ╩╚═╚═╝ ╩ ╚═╝╩╚═╝╚╝  ┴└─└─┘└─┘┴  └─┘┘└┘└─┘└─┘
+        return res.ok();
 
+      }//</on success>
+    });//</checkPassword().exec()>
+  });//</User.find().exec()>
 
-    //  ╔═╗╦╔╗╔╔╦╗  ┬ ┬┌─┐┌─┐┬─┐
-    //  ╠╣ ║║║║ ║║  │ │└─┐├┤ ├┬┘
-    //  ╚  ╩╝╚╝═╩╝  └─┘└─┘└─┘┴└─
-    // Look up by either username or email address.
-    User.findOne({
-      or: [
-        {
-          emailAddress: inputs.usernameOrEmail
-        },
-        {
-          username: inputs.usernameOrEmail
-        }
-      ]
-    })
-    .exec(function(err, userRecord) {
-      if(err) {
-        return exits.error(err);
-      }
-
-      // If there was no user, exit thru "notFound".
-      if(!userRecord) {
-        return exits.notFound();
-      }
-
-
-      //  ╔═╗╦ ╦╔═╗╔═╗╦╔═  ┌─┐┌─┐┌─┐┌─┐┬ ┬┌─┐┬─┐┌┬┐
-      //  ║  ╠═╣║╣ ║  ╠╩╗  ├─┘├─┤└─┐└─┐││││ │├┬┘ ││
-      //  ╚═╝╩ ╩╚═╝╚═╝╩ ╩  ┴  ┴ ┴└─┘└─┘└┴┘└─┘┴└──┴┘
-      stdlib('passwords').checkPassword({
-        passwordAttempt: inputs.password,
-        encryptedPassword: userRecord.password
-      }).exec({
-        error: function(err) {
-          return exits.error(err);
-        },
-        incorrect: function () {
-          // If the password doesn't match, then also
-          // exit thru "notFound" to prevent sniffing.
-          return exits.notFound();
-        },
-        success: function (){
-
-          //  ╦  ╔═╗╔═╗╦╔╗╔
-          //  ║  ║ ║║ ╦║║║║
-          //  ╩═╝╚═╝╚═╝╩╝╚╝
-          env.req.session.userId = userRecord.id;
-
-          //  ╦═╗╔═╗╔╦╗╦ ╦╦═╗╔╗╔  ┬─┐┌─┐┌─┐┌─┐┌─┐┌┐┌┌─┐┌─┐
-          //  ╠╦╝║╣  ║ ║ ║╠╦╝║║║  ├┬┘├┤ └─┐├─┘│ ││││└─┐├┤
-          //  ╩╚═╚═╝ ╩ ╚═╝╩╚═╝╚╝  ┴└─└─┘└─┘┴  └─┘┘└┘└─┘└─┘
-          return exits.success();
-
-        }//</on success>
-      });//</checkPassword().exec()>
-    });//</User.find().exec()>
-
-  }
-
-};
+}

--- a/lib/core-generators/action/templates/login-actions2.template
+++ b/lib/core-generators/action/templates/login-actions2.template
@@ -1,0 +1,124 @@
+module.exports = {
+
+
+  friendlyName: 'Login',
+
+
+  description: 'Log in using the provided username/email and password combination.',
+
+
+  extendedDescription:
+  'This action attempts to look up the user record in the database with the '+
+  'specified username (or email address).  Then, if such a user exists, it uses '+
+  'bcrypt to compare the hashed password from the database with the provided password '+
+  'attempt.',
+
+
+  inputs: {
+
+    usernameOrEmail: {
+      description: 'The username or email to try in this attempt, e.g. "particlebanana".',
+      type: 'string',
+      required: true
+    },
+
+    password: {
+      description: 'The unencrypted password to try in this attempt, e.g. "passwordlol".',
+      type: 'string',
+      required: true
+    }
+
+  },
+
+
+  exits: {
+
+    success: {
+      description: 'The requesting user agent has been successfully logged in.',
+      extendedDescription:
+      'Under the covers, this stores the id of the logged-in user in the session '+
+      'under the `userId` key.  The next time this user agent sends a request, assuming '+
+      'it includes a cookie (like a web browser), Sails will automatically make this '+
+      'user id available as `req.session.userId` in the corresponding action.'
+    },
+
+    notFound: {
+      description: 'The provided username/email and password combination does not '+
+      'match any user in the database.',
+      responseType: 'notFound'<% if (verbose) { %>,
+      // This uses the `notFound` response located in `api/responses/notFound.js`.
+      // To customize the generic "notFound" response across this entire app, change that file
+      // (see http://sailsjs.com/anatomy/api/responses/not-found-js).
+      //
+      // To customize the response for _only this_ action, replace `responseType` with `statusCode: 404`
+      // and change the implementation below accordingly (see http://sailsjs.com/docs/concepts/controllers).<% } %>
+    }
+
+  },
+
+
+  fn: function (inputs, exits, env) {
+
+    // Import dependencies
+    var stdlib = require('sails-stdlib');
+
+
+    //  ╔═╗╦╔╗╔╔╦╗  ┬ ┬┌─┐┌─┐┬─┐
+    //  ╠╣ ║║║║ ║║  │ │└─┐├┤ ├┬┘
+    //  ╚  ╩╝╚╝═╩╝  └─┘└─┘└─┘┴└─
+    // Look up by either username or email address.
+    User.findOne({
+      or: [
+        {
+          emailAddress: inputs.usernameOrEmail
+        },
+        {
+          username: inputs.usernameOrEmail
+        }
+      ]
+    })
+    .exec(function(err, userRecord) {
+      if(err) {
+        return exits.error(err);
+      }
+
+      // If there was no user, exit thru "notFound".
+      if(!userRecord) {
+        return exits.notFound();
+      }
+
+
+      //  ╔═╗╦ ╦╔═╗╔═╗╦╔═  ┌─┐┌─┐┌─┐┌─┐┬ ┬┌─┐┬─┐┌┬┐
+      //  ║  ╠═╣║╣ ║  ╠╩╗  ├─┘├─┤└─┐└─┐││││ │├┬┘ ││
+      //  ╚═╝╩ ╩╚═╝╚═╝╩ ╩  ┴  ┴ ┴└─┘└─┘└┴┘└─┘┴└──┴┘
+      stdlib('passwords').checkPassword({
+        passwordAttempt: inputs.password,
+        encryptedPassword: userRecord.password
+      }).exec({
+        error: function(err) {
+          return exits.error(err);
+        },
+        incorrect: function () {
+          // If the password doesn't match, then also
+          // exit thru "notFound" to prevent sniffing.
+          return exits.notFound();
+        },
+        success: function (){
+
+          //  ╦  ╔═╗╔═╗╦╔╗╔
+          //  ║  ║ ║║ ╦║║║║
+          //  ╩═╝╚═╝╚═╝╩╝╚╝
+          env.req.session.userId = userRecord.id;
+
+          //  ╦═╗╔═╗╔╦╗╦ ╦╦═╗╔╗╔  ┬─┐┌─┐┌─┐┌─┐┌─┐┌┐┌┌─┐┌─┐
+          //  ╠╦╝║╣  ║ ║ ║╠╦╝║║║  ├┬┘├┤ └─┐├─┘│ ││││└─┐├┤
+          //  ╩╚═╚═╝ ╩ ╚═╝╩╚═╝╚╝  ┴└─└─┘└─┘┴  └─┘┘└┘└─┘└─┘
+          return exits.success();
+
+        }//</on success>
+      });//</checkPassword().exec()>
+    });//</User.find().exec()>
+
+  }
+
+};

--- a/lib/core-generators/action/templates/logout-action.template
+++ b/lib/core-generators/action/templates/logout-action.template
@@ -11,4 +11,4 @@ module.exports = function (req, res) {
   //  This persists the now-empty session back to the underlying store.
   return res.ok();
 
-}
+};

--- a/lib/core-generators/action/templates/logout-action.template
+++ b/lib/core-generators/action/templates/logout-action.template
@@ -1,52 +1,14 @@
-module.exports = {
+module.exports = function (req, res) {
 
+  //  ╦ ╦╦╔═╗╔═╗  ┌─┐┌─┐┌─┐┌─┐┬┌─┐┌┐┌
+  //  ║║║║╠═╝║╣   └─┐├┤ └─┐└─┐││ ││││
+  //  ╚╩╝╩╩  ╚═╝  └─┘└─┘└─┘└─┘┴└─┘┘└┘
+  delete req.session.userId;
 
-  friendlyName: 'Log out',
+  //  ╔═╗╔═╗╔╗╔╔╦╗  ┬─┐┌─┐┌─┐┌─┐┌─┐┌┐┌┌─┐┌─┐
+  //  ╚═╗║╣ ║║║ ║║  ├┬┘├┤ └─┐├─┘│ ││││└─┐├┤
+  //  ╚═╝╚═╝╝╚╝═╩╝  ┴└─└─┘└─┘┴  └─┘┘└┘└─┘└─┘
+  //  This persists the now-empty session back to the underlying store.
+  return res.ok();
 
-
-  description: 'Log out of this app.',
-
-
-  extendedDescription:
-  'This action deletes the `userId` key from the session of the requesting user agent.  '+
-  'Actual garbage collection of session data depends on this app\'s session store, and '+
-  'potentially also on the '+
-  '[TTL configuration](http://sailsjs.com/docs/reference/configuration/sails-config-session) '+
-  'you provided for it.',
-
-
-  inputs: {
-
-  },
-
-
-  exits: {
-
-    success: {
-      description: 'The requesting user agent has been successfully logged out.',
-      extendedDescription:
-      'Note that this action calls the success exit _regardless_ of whether or '+
-      'not the user was actually logged in.  If they weren\'t, then this action '+
-      'simply does nothing.'
-    }
-
-  },
-
-
-  fn: function (inputs, exits, env) {
-
-    //  ╦ ╦╦╔═╗╔═╗  ┌─┐┌─┐┌─┐┌─┐┬┌─┐┌┐┌
-    //  ║║║║╠═╝║╣   └─┐├┤ └─┐└─┐││ ││││
-    //  ╚╩╝╩╩  ╚═╝  └─┘└─┘└─┘└─┘┴└─┘┘└┘
-    delete env.req.session.userId;
-
-    //  ╔═╗╔═╗╔╗╔╔╦╗  ┬─┐┌─┐┌─┐┌─┐┌─┐┌┐┌┌─┐┌─┐
-    //  ╚═╗║╣ ║║║ ║║  ├┬┘├┤ └─┐├─┘│ ││││└─┐├┤
-    //  ╚═╝╚═╝╝╚╝═╩╝  ┴└─└─┘└─┘┴  └─┘┘└┘└─┘└─┘
-    //  This persists the now-empty session back to the underlying store.
-    return exits.success();
-
-  }
-
-
-};
+}

--- a/lib/core-generators/action/templates/logout-actions2.template
+++ b/lib/core-generators/action/templates/logout-actions2.template
@@ -1,0 +1,52 @@
+module.exports = {
+
+
+  friendlyName: 'Log out',
+
+
+  description: 'Log out of this app.',
+
+
+  extendedDescription:
+  'This action deletes the `userId` key from the session of the requesting user agent.  '+
+  'Actual garbage collection of session data depends on this app\'s session store, and '+
+  'potentially also on the '+
+  '[TTL configuration](http://sailsjs.com/docs/reference/configuration/sails-config-session) '+
+  'you provided for it.',
+
+
+  inputs: {
+
+  },
+
+
+  exits: {
+
+    success: {
+      description: 'The requesting user agent has been successfully logged out.',
+      extendedDescription:
+      'Note that this action calls the success exit _regardless_ of whether or '+
+      'not the user was actually logged in.  If they weren\'t, then this action '+
+      'simply does nothing.'
+    }
+
+  },
+
+
+  fn: function (inputs, exits, env) {
+
+    //  ╦ ╦╦╔═╗╔═╗  ┌─┐┌─┐┌─┐┌─┐┬┌─┐┌┐┌
+    //  ║║║║╠═╝║╣   └─┐├┤ └─┐└─┐││ ││││
+    //  ╚╩╝╩╩  ╚═╝  └─┘└─┘└─┘└─┘┴└─┘┘└┘
+    delete env.req.session.userId;
+
+    //  ╔═╗╔═╗╔╗╔╔╦╗  ┬─┐┌─┐┌─┐┌─┐┌─┐┌┐┌┌─┐┌─┐
+    //  ╚═╗║╣ ║║║ ║║  ├┬┘├┤ └─┐├─┘│ ││││└─┐├┤
+    //  ╚═╝╚═╝╝╚╝═╩╝  ┴└─└─┘└─┘┴  └─┘┘└┘└─┘└─┘
+    //  This persists the now-empty session back to the underlying store.
+    return exits.success();
+
+  }
+
+
+};

--- a/lib/core-generators/action/templates/signup-action.template
+++ b/lib/core-generators/action/templates/signup-action.template
@@ -156,4 +156,4 @@ module.exports = function (req, res) {
 
   }); // </ stdlib('passwords').encryptPassword().exec() >
 
-}
+};

--- a/lib/core-generators/action/templates/signup-action.template
+++ b/lib/core-generators/action/templates/signup-action.template
@@ -1,214 +1,159 @@
-module.exports = {
+/**
+ * Module dependencies
+ */
+var stdlib = require('sails-stdlib');
 
+module.exports = function (req, res) {
 
-  friendlyName: 'Signup',
+  var username = req.param('username');
+  var password = req.param('password');
+  var emailAddress = req.param('emailAddress');
 
+  if (!username) { return res.badRequest(new Error('Missing `username` param')); }
+  if (!password) { return res.badRequest(new Error('Missing `password` param')); }
+  if (!emailAddress) { return res.badRequest(new Error('Missing `emailAddress` param')); }
 
-  description: 'Sign up for a new account.',
+  //  ╦╔╗╔╔═╗╦ ╦╔╦╗  ┬  ┬┌─┐┬  ┬┌┬┐┌─┐┌┬┐┬┌─┐┌┐┌┌─┐
+  //  ║║║║╠═╝║ ║ ║   └┐┌┘├─┤│  │ ││├─┤ │ ││ ││││└─┐
+  //  ╩╝╚╝╩  ╚═╝ ╩    └┘ ┴ ┴┴─┘┴─┴┘┴ ┴ ┴ ┴└─┘┘└┘└─┘
 
-
-  inputs: {
-
-    emailAddress: {
-      description: 'The email address for the new account, e.g. "m@example.com".',
-      extendedDescription: 'See `helpers/validate-email-address.js` for details about email address validation.',
-      type: 'string',
-      required: true
-    },
-
-    username: {
-      description: 'The username for the new account, e.g. "mikermcneil".',
-      extendedDescription:
-      'See `helpers/validate-user-username.js` for details about username validation.  '+
-      'To summarize: Username may only contain alphanumeric characters or single dashes (AND WE MEAN SINGLE!  '+
-      'No `i------like---ice--cream`.), and cannot begin or end with a dash.  Usernames will always be lowercased.  '+
-      'Also, usernames are checked against a blacklist. The words in `constants/username-blacklist.js` are reserved, '+
-      'and cannot be used as usernames.',
-      type: 'string',
-      required: true
-    },
-
-    password: {
-      description: 'The unencrypted password to use for the new account, e.g. "passwordlol".',
-      extendedDescription:
-      'See `helpers/validate-password-strict.js` for details about password validation.  '+
-      'To summarize: Password must be at least 7 characters, and max 72 characters.  Anything goes.',
-      type: 'string',
-      required: true
+  // Strictly validate the password.
+  try {
+    sails.helpers.validateUserPasswordStrict({
+      string: password
+    }).execSync();
+  } catch (e) {
+    switch (e.exit) {
+      case undefined:
+      case 'error':
+        return res.serverError(new Error('Consistency violation: Unexpected internal error (i.e. bug in our code) when validating the password provided during signup.  Details: '+e.stack));
+      default:
+        return res.serverError(new Error('Server-side validation failed for provided password.  This should NEVER happen in normal use of this app (because it SHOULD have been validated/coerced on the front-end).  So, either there is a bug somewhere (potentially in our front-end code), or this is a deliberate poke at our API from a curious individual.  Details: '+e.stack));
     }
-
-  },
-
-
-  exits: {
-
-    success: {
-      description: 'The new user account was created in the database, and the requesting user agent '+
-      'has been logged in.'
-    },
-
-    emailAlreadyInUse: {
-      statusCode: 409,
-      description: 'The provided email address is already in use.',
-    },
-
-    usernameAlreadyInUse: {
-      statusCode: 409,
-      description: 'The provided username is already in use.',
-    }
-
-  },
-
-
-  fn: function (inputs, exits, env) {
-
-    // Import dependencies
-    var stdlib = require('sails-stdlib');
-
-
-    //  ╦╔╗╔╔═╗╦ ╦╔╦╗  ┬  ┬┌─┐┬  ┬┌┬┐┌─┐┌┬┐┬┌─┐┌┐┌┌─┐
-    //  ║║║║╠═╝║ ║ ║   └┐┌┘├─┤│  │ ││├─┤ │ ││ ││││└─┐
-    //  ╩╝╚╝╩  ╚═╝ ╩    └┘ ┴ ┴┴─┘┴─┴┘┴ ┴ ┴ ┴└─┘┘└┘└─┘
-
-    // Strictly validate the password.
-    try {
-      sails.helpers.validateUserPasswordStrict({
-        string: inputs.password
-      }).execSync();
-    } catch (e) {
-      switch (e.exit) {
-        case undefined:
-        case 'error':
-          return exits.error(new Error('Consistency violation: Unexpected internal error (i.e. bug in our code) when validating the password provided during signup.  Details: '+e.stack));
-        default:
-          return exits.error(new Error('Server-side validation failed for provided password.  This should NEVER happen in normal use of this app (because it SHOULD have been validated/coerced on the front-end).  So, either there is a bug somewhere (potentially in our front-end code), or this is a deliberate poke at our API from a curious individual.  Details: '+e.stack));
-      }
-    }
-
-    // Strictly validate username
-    // (Note that coercion must take place on the front-end before sending the request.)
-    try {
-      sails.helpers.validateUserUsername({
-        string: inputs.username,
-        strict: true
-      }).execSync();
-    } catch (e) {
-      switch (e.exit) {
-        case undefined:
-        case 'error':
-          return exits.error(new Error('Consistency violation: Unexpected internal error (i.e. bug in our code) when validating the username provided during signup.  Details: '+e.stack));
-        case 'notAvailable':
-        case 'inUse':
-          return exits.usernameAlreadyInUse();
-        default:
-          return exits.error(new Error('Server-side validation failed for provided username (`'+inputs.username+'`).  This should NEVER happen in normal use of this app (because it SHOULD have been validated/coerced on the front-end).  So, either there is a bug somewhere (potentially in our front-end code), or this is a deliberate poke at our API from a curious individual.  Details: '+e.stack));
-      }
-    }
-
-    // Strictly validate the email address.
-    // (Note that coercion must take place on the front-end before sending the request.)
-    try {
-      sails.helpers.validateEmailAddress({
-        string: inputs.emailAddress,
-        strict: true
-      }).execSync();
-    } catch (e) {
-      switch (e.exit) {
-        case undefined:
-        case 'error':
-          return exits.error(new Error('Consistency violation: Unexpected internal error (i.e. bug in our code) when validating the email address provided during signup.  Details: '+e.stack));
-        default:
-          return exits.error(new Error('Server-side validation failed for provided email address (`'+inputs.emailAddress+'`).  This should NEVER happen in normal use of this app (because it SHOULD have been validated/coerced on the front-end).  So, either there is a bug somewhere (potentially in our front-end code), or this is a deliberate poke at our API from a curious individual.  Details: '+e.stack));
-      }
-    }
-
-
-    //  ╔═╗╔╗╔╔═╗╦═╗╦ ╦╔═╗╔╦╗  ┌─┐┌─┐┌─┐┌─┐┬ ┬┌─┐┬─┐┌┬┐
-    //  ║╣ ║║║║  ╠╦╝╚╦╝╠═╝ ║   ├─┘├─┤└─┐└─┐││││ │├┬┘ ││
-    //  ╚═╝╝╚╝╚═╝╩╚═ ╩ ╩   ╩   ┴  ┴ ┴└─┘└─┘└┴┘└─┘┴└──┴┘
-
-    stdlib('passwords').encryptPassword({
-      password: inputs.password
-    }).exec(function(err, hashed) {
-      if(err) {
-        return exits.error(new Error('Cannot encrypt password.  Details: '+err.stack));
-      }
-
-      //  ╔═╗╔═╗╦  ╦╔═╗  ┬ ┬┌─┐┌─┐┬─┐
-      //  ╚═╗╠═╣╚╗╔╝║╣   │ │└─┐├┤ ├┬┘
-      //  ╚═╝╩ ╩ ╚╝ ╚═╝  └─┘└─┘└─┘┴└─
-
-      // Build up the data for the user record
-      var newUserData = {
-        emailAddress: inputs.emailAddress,
-        username: inputs.username,
-        password: hashed,
-        humanName: ''<% if (verbose){%>,
-        // And initial values for other attributes; e.g.
-        // plan: 'free', // << all new users default to the "free" plan
-        // isSuspended: false<% } %>
-      };
-
-      // Try to create a user record.
-      User.create(newUserData)
-      .exec(function(err, newUserRecord) {
-        try {
-
-
-          //  ╔╗╔╔═╗╔═╗╔═╗╔╦╗╦╔═╗╔╦╗╔═╗  ┌─┐┬─┐┬─┐┌─┐┬─┐
-          //  ║║║║╣ ║ ╦║ ║ ║ ║╠═╣ ║ ║╣   ├┤ ├┬┘├┬┘│ │├┬┘
-          //  ╝╚╝╚═╝╚═╝╚═╝ ╩ ╩╩ ╩ ╩ ╚═╝  └─┘┴└─┴└─└─┘┴└─
-          // Inspect the error and figure out what type of exit to return
-          if(err) {
-
-            // Check for a validation error (aka UNIQUENESS)
-            if(err.code !== 'E_VALIDATION') {
-              return exits.error(err);
-            }
-
-            // Grab the first invalid attribute and see what caused it. In this
-            // case it *SHOULD* only ever be the violation of a uniqueness constraint.
-            var invalidAttribute = _.first(_.keys(err.invalidAttributes));
-            var duplicateError = _.find(err.invalidAttributes[invalidAttribute], { rule: 'unique'} );
-
-            // If a duplicate error was found, call the correct exit based on
-            // what the attribute was.
-            if(duplicateError) {
-              if(invalidAttribute === 'emailAddress') {
-                return exits.emailAlreadyInUse();
-              }
-
-              if(invalidAttribute === 'username') {
-                return exits.usernameAlreadyInUse();
-              }
-            }
-
-            // Otherwise just exit with the error.
-            return exits.error(err);
-          }
-
-          // --•
-          // If we made it here, the user record was successfully created.
-
-          //  ╦  ╔═╗╔═╗╦╔╗╔  ┬ ┬┌─┐┌─┐┬─┐
-          //  ║  ║ ║║ ╦║║║║  │ │└─┐├┤ ├┬┘
-          //  ╩═╝╚═╝╚═╝╩╝╚╝  └─┘└─┘└─┘┴└─
-          // Store the user id in the session
-          env.req.session.userId = newUserRecord.id;
-
-
-          //  ╦═╗╔═╗╔╦╗╦ ╦╦═╗╔╗╔  ┬─┐┌─┐┌─┐┌─┐┌─┐┌┐┌┌─┐┌─┐
-          //  ╠╦╝║╣  ║ ║ ║╠╦╝║║║  ├┬┘├┤ └─┐├─┘│ ││││└─┐├┤
-          //  ╩╚═╚═╝ ╩ ╚═╝╩╚═╝╚╝  ┴└─└─┘└─┘┴  └─┘┘└┘└─┘└─┘
-          // If everything went ok, call the success exit.
-          return exits.success();
-
-        } catch (e){ return exits.error(e); }
-
-      }); // </ User.create().exec() >
-
-    }); // </ stdlib('passwords').encryptPassword().exec() >
-
   }
 
-};
+  // Strictly validate username
+  // (Note that coercion must take place on the front-end before sending the request.)
+  try {
+    sails.helpers.validateUserUsername({
+      string: username,
+      strict: true
+    }).execSync();
+  } catch (e) {
+    switch (e.exit) {
+      case undefined:
+      case 'error':
+        return res.serverError(new Error('Consistency violation: Unexpected internal error (i.e. bug in our code) when validating the username provided during signup.  Details: '+e.stack));
+      case 'notAvailable':
+      case 'inUse':
+        return res.badRequest(new Error('That email address is already in use'));
+      default:
+        return res.serverError(new Error('Server-side validation failed for provided username (`'+username+'`).  This should NEVER happen in normal use of this app (because it SHOULD have been validated/coerced on the front-end).  So, either there is a bug somewhere (potentially in our front-end code), or this is a deliberate poke at our API from a curious individual.  Details: '+e.stack));
+    }
+  }
+
+  // Strictly validate the email address.
+  // (Note that coercion must take place on the front-end before sending the request.)
+  try {
+    sails.helpers.validateEmailAddress({
+      string: emailAddress,
+      strict: true
+    }).execSync();
+  } catch (e) {
+    switch (e.exit) {
+      case undefined:
+      case 'error':
+        return res.serverError(new Error('Consistency violation: Unexpected internal error (i.e. bug in our code) when validating the email address provided during signup.  Details: '+e.stack));
+      default:
+        return res.serverError(new Error('Server-side validation failed for provided email address (`'+emailAddress+'`).  This should NEVER happen in normal use of this app (because it SHOULD have been validated/coerced on the front-end).  So, either there is a bug somewhere (potentially in our front-end code), or this is a deliberate poke at our API from a curious individual.  Details: '+e.stack));
+    }
+  }
+
+
+  //  ╔═╗╔╗╔╔═╗╦═╗╦ ╦╔═╗╔╦╗  ┌─┐┌─┐┌─┐┌─┐┬ ┬┌─┐┬─┐┌┬┐
+  //  ║╣ ║║║║  ╠╦╝╚╦╝╠═╝ ║   ├─┘├─┤└─┐└─┐││││ │├┬┘ ││
+  //  ╚═╝╝╚╝╚═╝╩╚═ ╩ ╩   ╩   ┴  ┴ ┴└─┘└─┘└┴┘└─┘┴└──┴┘
+
+  stdlib('passwords').encryptPassword({
+    password: password
+  }).exec(function(err, hashed) {
+    if(err) {
+      return res.serverError(new Error('Cannot encrypt password.  Details: '+err.stack));
+    }
+
+    //  ╔═╗╔═╗╦  ╦╔═╗  ┬ ┬┌─┐┌─┐┬─┐
+    //  ╚═╗╠═╣╚╗╔╝║╣   │ │└─┐├┤ ├┬┘
+    //  ╚═╝╩ ╩ ╚╝ ╚═╝  └─┘└─┘└─┘┴└─
+
+    // Build up the data for the user record
+    var newUserData = {
+      emailAddress: emailAddress,
+      username: username,
+      password: hashed,
+      humanName: ''<% if (verbose){%>,
+      // And initial values for other attributes; e.g.
+      // plan: 'free', // << all new users default to the "free" plan
+      // isSuspended: false<% } %>
+    };
+
+    // Try to create a user record.
+    User.create(newUserData)
+    .exec(function(err, newUserRecord) {
+      try {
+
+
+        //  ╔╗╔╔═╗╔═╗╔═╗╔╦╗╦╔═╗╔╦╗╔═╗  ┌─┐┬─┐┬─┐┌─┐┬─┐
+        //  ║║║║╣ ║ ╦║ ║ ║ ║╠═╣ ║ ║╣   ├┤ ├┬┘├┬┘│ │├┬┘
+        //  ╝╚╝╚═╝╚═╝╚═╝ ╩ ╩╩ ╩ ╩ ╚═╝  └─┘┴└─┴└─└─┘┴└─
+        // Inspect the error and figure out what type of exit to return
+        if(err) {
+
+          // Check for a validation error (aka UNIQUENESS)
+          if(err.code !== 'E_VALIDATION') {
+            return res.serverError(err);
+          }
+
+          // Grab the first invalid attribute and see what caused it. In this
+          // case it *SHOULD* only ever be the violation of a uniqueness constraint.
+          var invalidAttribute = _.first(_.keys(err.invalidAttributes));
+          var duplicateError = _.find(err.invalidAttributes[invalidAttribute], { rule: 'unique'} );
+
+          // If a duplicate error was found, call the correct exit based on
+          // what the attribute was.
+          if(duplicateError) {
+            if(invalidAttribute === 'emailAddress') {
+              return res.badRequest(new Error('That email address is already in use'));
+            }
+
+            if(invalidAttribute === 'username') {
+              return res.badRequest(new Error('That username is already in use'));
+            }
+          }
+
+          // Otherwise just exit with the error.
+          return res.serverError(err);
+        }
+
+        // --•
+        // If we made it here, the user record was successfully created.
+
+        //  ╦  ╔═╗╔═╗╦╔╗╔  ┬ ┬┌─┐┌─┐┬─┐
+        //  ║  ║ ║║ ╦║║║║  │ │└─┐├┤ ├┬┘
+        //  ╩═╝╚═╝╚═╝╩╝╚╝  └─┘└─┘└─┘┴└─
+        // Store the user id in the session
+        req.session.userId = newUserRecord.id;
+
+
+        //  ╦═╗╔═╗╔╦╗╦ ╦╦═╗╔╗╔  ┬─┐┌─┐┌─┐┌─┐┌─┐┌┐┌┌─┐┌─┐
+        //  ╠╦╝║╣  ║ ║ ║╠╦╝║║║  ├┬┘├┤ └─┐├─┘│ ││││└─┐├┤
+        //  ╩╚═╚═╝ ╩ ╚═╝╩╚═╝╚╝  ┴└─└─┘└─┘┴  └─┘┘└┘└─┘└─┘
+        // If everything went ok, call the success exit.
+        return res.ok();
+
+      } catch (e){ return res.serverError(e); }
+
+    }); // </ User.create().exec() >
+
+  }); // </ stdlib('passwords').encryptPassword().exec() >
+
+}

--- a/lib/core-generators/action/templates/signup-actions2.template
+++ b/lib/core-generators/action/templates/signup-actions2.template
@@ -1,0 +1,214 @@
+module.exports = {
+
+
+  friendlyName: 'Signup',
+
+
+  description: 'Sign up for a new account.',
+
+
+  inputs: {
+
+    emailAddress: {
+      description: 'The email address for the new account, e.g. "m@example.com".',
+      extendedDescription: 'See `helpers/validate-email-address.js` for details about email address validation.',
+      type: 'string',
+      required: true
+    },
+
+    username: {
+      description: 'The username for the new account, e.g. "mikermcneil".',
+      extendedDescription:
+      'See `helpers/validate-user-username.js` for details about username validation.  '+
+      'To summarize: Username may only contain alphanumeric characters or single dashes (AND WE MEAN SINGLE!  '+
+      'No `i------like---ice--cream`.), and cannot begin or end with a dash.  Usernames will always be lowercased.  '+
+      'Also, usernames are checked against a blacklist. The words in `constants/username-blacklist.js` are reserved, '+
+      'and cannot be used as usernames.',
+      type: 'string',
+      required: true
+    },
+
+    password: {
+      description: 'The unencrypted password to use for the new account, e.g. "passwordlol".',
+      extendedDescription:
+      'See `helpers/validate-password-strict.js` for details about password validation.  '+
+      'To summarize: Password must be at least 7 characters, and max 72 characters.  Anything goes.',
+      type: 'string',
+      required: true
+    }
+
+  },
+
+
+  exits: {
+
+    success: {
+      description: 'The new user account was created in the database, and the requesting user agent '+
+      'has been logged in.'
+    },
+
+    emailAlreadyInUse: {
+      statusCode: 409,
+      description: 'The provided email address is already in use.',
+    },
+
+    usernameAlreadyInUse: {
+      statusCode: 409,
+      description: 'The provided username is already in use.',
+    }
+
+  },
+
+
+  fn: function (inputs, exits, env) {
+
+    // Import dependencies
+    var stdlib = require('sails-stdlib');
+
+
+    //  ╦╔╗╔╔═╗╦ ╦╔╦╗  ┬  ┬┌─┐┬  ┬┌┬┐┌─┐┌┬┐┬┌─┐┌┐┌┌─┐
+    //  ║║║║╠═╝║ ║ ║   └┐┌┘├─┤│  │ ││├─┤ │ ││ ││││└─┐
+    //  ╩╝╚╝╩  ╚═╝ ╩    └┘ ┴ ┴┴─┘┴─┴┘┴ ┴ ┴ ┴└─┘┘└┘└─┘
+
+    // Strictly validate the password.
+    try {
+      sails.helpers.validateUserPasswordStrict({
+        string: inputs.password
+      }).execSync();
+    } catch (e) {
+      switch (e.exit) {
+        case undefined:
+        case 'error':
+          return exits.error(new Error('Consistency violation: Unexpected internal error (i.e. bug in our code) when validating the password provided during signup.  Details: '+e.stack));
+        default:
+          return exits.error(new Error('Server-side validation failed for provided password.  This should NEVER happen in normal use of this app (because it SHOULD have been validated/coerced on the front-end).  So, either there is a bug somewhere (potentially in our front-end code), or this is a deliberate poke at our API from a curious individual.  Details: '+e.stack));
+      }
+    }
+
+    // Strictly validate username
+    // (Note that coercion must take place on the front-end before sending the request.)
+    try {
+      sails.helpers.validateUserUsername({
+        string: inputs.username,
+        strict: true
+      }).execSync();
+    } catch (e) {
+      switch (e.exit) {
+        case undefined:
+        case 'error':
+          return exits.error(new Error('Consistency violation: Unexpected internal error (i.e. bug in our code) when validating the username provided during signup.  Details: '+e.stack));
+        case 'notAvailable':
+        case 'inUse':
+          return exits.usernameAlreadyInUse();
+        default:
+          return exits.error(new Error('Server-side validation failed for provided username (`'+inputs.username+'`).  This should NEVER happen in normal use of this app (because it SHOULD have been validated/coerced on the front-end).  So, either there is a bug somewhere (potentially in our front-end code), or this is a deliberate poke at our API from a curious individual.  Details: '+e.stack));
+      }
+    }
+
+    // Strictly validate the email address.
+    // (Note that coercion must take place on the front-end before sending the request.)
+    try {
+      sails.helpers.validateEmailAddress({
+        string: inputs.emailAddress,
+        strict: true
+      }).execSync();
+    } catch (e) {
+      switch (e.exit) {
+        case undefined:
+        case 'error':
+          return exits.error(new Error('Consistency violation: Unexpected internal error (i.e. bug in our code) when validating the email address provided during signup.  Details: '+e.stack));
+        default:
+          return exits.error(new Error('Server-side validation failed for provided email address (`'+inputs.emailAddress+'`).  This should NEVER happen in normal use of this app (because it SHOULD have been validated/coerced on the front-end).  So, either there is a bug somewhere (potentially in our front-end code), or this is a deliberate poke at our API from a curious individual.  Details: '+e.stack));
+      }
+    }
+
+
+    //  ╔═╗╔╗╔╔═╗╦═╗╦ ╦╔═╗╔╦╗  ┌─┐┌─┐┌─┐┌─┐┬ ┬┌─┐┬─┐┌┬┐
+    //  ║╣ ║║║║  ╠╦╝╚╦╝╠═╝ ║   ├─┘├─┤└─┐└─┐││││ │├┬┘ ││
+    //  ╚═╝╝╚╝╚═╝╩╚═ ╩ ╩   ╩   ┴  ┴ ┴└─┘└─┘└┴┘└─┘┴└──┴┘
+
+    stdlib('passwords').encryptPassword({
+      password: inputs.password
+    }).exec(function(err, hashed) {
+      if(err) {
+        return exits.error(new Error('Cannot encrypt password.  Details: '+err.stack));
+      }
+
+      //  ╔═╗╔═╗╦  ╦╔═╗  ┬ ┬┌─┐┌─┐┬─┐
+      //  ╚═╗╠═╣╚╗╔╝║╣   │ │└─┐├┤ ├┬┘
+      //  ╚═╝╩ ╩ ╚╝ ╚═╝  └─┘└─┘└─┘┴└─
+
+      // Build up the data for the user record
+      var newUserData = {
+        emailAddress: inputs.emailAddress,
+        username: inputs.username,
+        password: hashed,
+        humanName: ''<% if (verbose){%>,
+        // And initial values for other attributes; e.g.
+        // plan: 'free', // << all new users default to the "free" plan
+        // isSuspended: false<% } %>
+      };
+
+      // Try to create a user record.
+      User.create(newUserData)
+      .exec(function(err, newUserRecord) {
+        try {
+
+
+          //  ╔╗╔╔═╗╔═╗╔═╗╔╦╗╦╔═╗╔╦╗╔═╗  ┌─┐┬─┐┬─┐┌─┐┬─┐
+          //  ║║║║╣ ║ ╦║ ║ ║ ║╠═╣ ║ ║╣   ├┤ ├┬┘├┬┘│ │├┬┘
+          //  ╝╚╝╚═╝╚═╝╚═╝ ╩ ╩╩ ╩ ╩ ╚═╝  └─┘┴└─┴└─└─┘┴└─
+          // Inspect the error and figure out what type of exit to return
+          if(err) {
+
+            // Check for a validation error (aka UNIQUENESS)
+            if(err.code !== 'E_VALIDATION') {
+              return exits.error(err);
+            }
+
+            // Grab the first invalid attribute and see what caused it. In this
+            // case it *SHOULD* only ever be the violation of a uniqueness constraint.
+            var invalidAttribute = _.first(_.keys(err.invalidAttributes));
+            var duplicateError = _.find(err.invalidAttributes[invalidAttribute], { rule: 'unique'} );
+
+            // If a duplicate error was found, call the correct exit based on
+            // what the attribute was.
+            if(duplicateError) {
+              if(invalidAttribute === 'emailAddress') {
+                return exits.emailAlreadyInUse();
+              }
+
+              if(invalidAttribute === 'username') {
+                return exits.usernameAlreadyInUse();
+              }
+            }
+
+            // Otherwise just exit with the error.
+            return exits.error(err);
+          }
+
+          // --•
+          // If we made it here, the user record was successfully created.
+
+          //  ╦  ╔═╗╔═╗╦╔╗╔  ┬ ┬┌─┐┌─┐┬─┐
+          //  ║  ║ ║║ ╦║║║║  │ │└─┐├┤ ├┬┘
+          //  ╩═╝╚═╝╚═╝╩╝╚╝  └─┘└─┘└─┘┴└─
+          // Store the user id in the session
+          env.req.session.userId = newUserRecord.id;
+
+
+          //  ╦═╗╔═╗╔╦╗╦ ╦╦═╗╔╗╔  ┬─┐┌─┐┌─┐┌─┐┌─┐┌┐┌┌─┐┌─┐
+          //  ╠╦╝║╣  ║ ║ ║╠╦╝║║║  ├┬┘├┤ └─┐├─┘│ ││││└─┐├┤
+          //  ╩╚═╚═╝ ╩ ╚═╝╩╚═╝╚╝  ┴└─└─┘└─┘┴  └─┘┘└┘└─┘└─┘
+          // If everything went ok, call the success exit.
+          return exits.success();
+
+        } catch (e){ return exits.error(e); }
+
+      }); // </ User.create().exec() >
+
+    }); // </ stdlib('passwords').encryptPassword().exec() >
+
+  }
+
+};


### PR DESCRIPTION
For manageability's sake, also refactored the way alternate templates are used by setting the target directly instead of using `getAlternativeTemplate`.  Verified that this works, but if there's a reason to keep it the other way I can switch it back.