### PR TITLE
Check for a core generator before looking in node_modules

### DIFF
--- a/lib/load-generator-def.js
+++ b/lib/load-generator-def.js
@@ -147,6 +147,11 @@ module.exports = function loadGeneratorDef(options) {
   // Otherwise NO generator package name / module path was provided, so try a few other things.
   else {
 
+    // First, try resolving this as a core generator (`core-generators/` in THIS PACKAGE)
+    requiresToAttempt.push(
+      path.resolve(__dirname, './core-generators', options.generatorType)
+    );
+
     // ====================================================================================================
     // <FOR BACKWARDS COMPAT>
     // ====================================================================================================
@@ -168,12 +173,6 @@ module.exports = function loadGeneratorDef(options) {
     // ====================================================================================================
     // </FOR BACKWARDS COMPAT>
     // ====================================================================================================
-
-    // 1.
-    // Finally, try resolving this as a core generator (`core-generators/` in THIS PACKAGE)
-    requiresToAttempt.push(
-      path.resolve(__dirname, './core-generators', options.generatorType)
-    );
 
   }//</else>
   //>-


### PR DESCRIPTION
This still allows overriding core generators, just not by `npm install`ing them.