### PR TITLE
Standardized redis url format to what is used in site documentation for db (numerical database names only).

### DIFF
--- a/lib/core-generators/new/templates/config/env/production.js.template
+++ b/lib/core-generators/new/templates/config/env/production.js.template
@@ -185,14 +185,14 @@ module.exports = {
     *                                                                          *
     ***************************************************************************/
     // adapter: '@sailshq/connect-redis',
-    // url: 'redis://user:password@localhost:6379/dbname',
+    // url: 'redis://user:password@localhost:6379/dbindex',
     //--------------------------------------------------------------------------
     // /\   OR, to avoid checking it in to version control, you might opt to
     // ||   set sensitive credentials like this using an environment variable.
     //
     // For example:
     // ```
-    // sails_session__url=redis://admin:myc00lpAssw2D@bigsquid.redistogo.com:9562/sessions
+    // sails_session__url=redis://admin:myc00lpAssw2D@bigsquid.redistogo.com:9562/5
     // ```
     //
     //--------------------------------------------------------------------------


### PR DESCRIPTION
https://sailsjs.com/documentation/reference/configuration/sails-config-session