### PR TITLE
Bump machinepack-process version to 4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "flaverr": "^1.0.0",
     "fs-extra": "0.30.0",
     "lodash": "3.10.1",
-    "machinepack-process": "^2.0.2",
+    "machinepack-process": "^4.0.0",
     "parasails": "^0.7.1",
     "read": "1.0.7",
     "reportback": "^2.0.1",


### PR DESCRIPTION
Ran local tests using machinepack-process v4.0.0 in sails v1.1.0 to test "sails new" and found no issues. Unit tests are all green testing the sails-generate package using 'npm run test' as well. Suggest bumping version from 2.0.2 which depends on the vulnerable and deprecated package 'open', to the latest release, as the major version change does not in-fact cause breaking changes.