### PR TITLE
[bugfix] `generate new --without` splits the args twice

### DIFF
--- a/lib/core-generators/new/before.js
+++ b/lib/core-generators/new/before.js
@@ -163,11 +163,6 @@ module.exports = function before (scope, done) {
         website: util.format('https://github.com/%s', owner)
       });
 
-      // To avoid confusion, disable the `async` dependency by default.
-      if (!_.contains(scope.without, 'async')) {
-        scope.without = _.uniq((scope.without||[]).concat(['async']));
-      }
-
       // Provide a shortcut for generating an extremely minimal Sails app.
       if (scope.minimal) {
         scope.without = ['i18n','orm','sockets','grunt','lodash','async','session','views'];
@@ -235,6 +230,11 @@ module.exports = function before (scope, done) {
       if (!_.isArray(scope.without)) {
         return done(new Error('Couldn\'t create a new Sails app.  The provided `without` option (`'+util.inspect(scope.without, {depth:null})+'`) is invalid.'));
       }//-•
+
+      // To avoid confusion, disable the `async` dependency by default.
+      if (!_.contains(scope.without, 'async')) {
+        scope.without = _.uniq((scope.without||[]).concat(['async']));
+      }
 
       // Reject unrecognized "without" entries
       var LEGAL_WITHOUT_IDENTIFIERS = ['lodash', 'async', 'orm', 'sockets', 'grunt', 'i18n', 'session', 'views'];


### PR DESCRIPTION
Already reported on sails repo, https://github.com/balderdashy/sails/issues/4566

This will fix usage problem when `generate new` is used with `--without` option and keep removing async by default