### PR TITLE
Give custom form validators a `this` context relative to the Vue component

### DIFF
--- a/lib/core-generators/new/templates/assets/js/components/ajax-form.component.js
+++ b/lib/core-generators/new/templates/assets/js/components/ajax-form.component.js
@@ -277,7 +277,7 @@ parasails.registerComponent('ajaxForm', {
               // ® Provided function must return truthy when invoked with the value.
               try {
                 violation = (
-                  !ruleRhs(fieldValue)
+                  !ruleRhs.call(this, fieldValue)
                 );
               } catch (err) {
                 console.warn(err);


### PR DESCRIPTION
Could be useful if the validity of one form field is dependent on the state of another.

Some out-of-context nonsense example:
```js

formData: {
  foo: 'foo',
  bar: 'bar',
},

formRules: {
  bar: {
    custom: function(input) {
      return input === 'bar' && this.foo !== 'bar';
    }
  }
}

```