### PR TITLE
[proposal] Add ability to override Mailgun host. 

### DIFF
--- a/lib/core-generators/new/templates/api/hooks/custom/index.js.template
+++ b/lib/core-generators/new/templates/api/hooks/custom/index.js.template
@@ -84,6 +84,7 @@ will be disabled and/or hidden in the UI.
         sails.helpers.mailgun.configure({
           secret: sails.config.custom.mailgunSecret,
           domain: sails.config.custom.mailgunDomain,
+          hosy: sails.config.custom.mailgunHost,
           from: sails.config.custom.fromEmailAddress,
           fromName: sails.config.custom.fromName,
         });

--- a/lib/core-generators/new/templates/config/custom.js.template
+++ b/lib/core-generators/new/templates/config/custom.js.template
@@ -48,11 +48,15 @@ module.exports.custom = {
   * other default settings related to "how" and "where" automated emails    *
   * are sent.                                                               *
   *                                                                         *
+  * EU accounts on Mailgun needs to use 'api.eu.mailgun.com' as host, while *
+  * every one else can ignore the setting.                                  *
+  *                                                                         *
   * (https://app.mailgun.com/app/domains)                                   *
   *                                                                         *
   **************************************************************************/
   // mailgunDomain: 'sandboxaa1234fake678.mailgun.org',
   // mailgunSecret: 'key-fakeb183848139913858e8abd9a3',
+  // mailgunHost: 'api.eu.mailgun.net',
   //--------------------------------------------------------------------------
   // /\  Configure these to enable support for automated emails.
   // ||  (Important for password recovery, verification, contact form, etc.)


### PR DESCRIPTION
Depends upon 'sails-hook-organics' PR #4.

This PR adds the ability to override the Mailgun host in a user friendly way. The PR just updates the templates for the generated files 'api/hooks/custom/index.js' and 'config/custom.js' to include loading of the new property, as well as instructions for EU based users, who are the only ones affected.

Please reference @rachaelshaw for more info on the discussion from Gitter where these were approved as a valid proposed feature PRs.