### PR TITLE
Upgrade dependencies for newly-generated apps

### DIFF
--- a/lib/core-generators/new/get-package-json-data.js
+++ b/lib/core-generators/new/get-package-json-data.js
@@ -155,17 +155,16 @@ module.exports = function getPackageJsonData(scope) {
       ),
       lint: (
         scope.caviar? (
-          'eslint . --max-warnings=0 --report-unused-disable-directives && '+
+          './node_modules/eslint/bin/eslint.js . --max-warnings=0 --report-unused-disable-directives && '+
           'echo \'✔  Your .js files look so good.\' && '+
-          'htmlhint -c ./.htmlhintrc views/*.ejs && htmlhint -c ./.htmlhintrc views/**/*.ejs && htmlhint -c ./.htmlhintrc views/**/**/*.ejs && htmlhint -c ./.htmlhintrc views/**/**/**/*.ejs && htmlhint -c ./.htmlhintrc views/**/**/**/**/*.ejs && htmlhint -c ./.htmlhintrc views/**/**/**/**/**/*.ejs && htmlhint -c ./.htmlhintrc views/**/**/**/**/**/**/*.ejs && '+
+          './node_modules/@sailshq/htmlhint/bin/htmlhint -c ./.htmlhintrc views/*.ejs && ./node_modules/@sailshq/htmlhint/bin/htmlhint -c ./.htmlhintrc views/**/*.ejs && ./node_modules/@sailshq/htmlhint/bin/htmlhint -c ./.htmlhintrc views/**/**/*.ejs && ./node_modules/@sailshq/htmlhint/bin/htmlhint -c ./.htmlhintrc views/**/**/**/*.ejs && ./node_modules/@sailshq/htmlhint/bin/htmlhint -c ./.htmlhintrc views/**/**/**/**/*.ejs && ./node_modules/@sailshq/htmlhint/bin/htmlhint -c ./.htmlhintrc views/**/**/**/**/**/*.ejs && ./node_modules/@sailshq/htmlhint/bin/htmlhint -c ./.htmlhintrc views/**/**/**/**/**/**/*.ejs && '+
           'echo \'✔  So do your .ejs files.\' && '+
-          'lesshint assets/styles/ --max-warnings=0 && '+
+          './node_modules/@sailshq/lesshint/bin/lesshint assets/styles/ --max-warnings=0 && '+
           'echo \'✔  Your .less files look good, too.\''
         ) : (
-          'eslint . --max-warnings=0 --report-unused-disable-directives && '+
+          './node_modules/eslint/bin/eslint.js . --max-warnings=0 --report-unused-disable-directives && '+
           'echo \'✔  Your .js files look good.\''
         )
-
 
         // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
         // FUTURE: Set up something like:

--- a/lib/core-generators/new/get-package-json-data.js
+++ b/lib/core-generators/new/get-package-json-data.js
@@ -133,7 +133,7 @@ module.exports = function getPackageJsonData(scope) {
       'eslint': '5.16.0',
 
       // Caviar only:
-      '@sailshq/htmlhint': scope.caviar? '^0.9.16': undefined,// « FUTURE: Explore options w/ ejslint (https://www.npmjs.com/package/ejs-lint)
+      'htmlhint': scope.caviar? '0.11.0': undefined,// « FUTURE: Explore options w/ ejslint (https://www.npmjs.com/package/ejs-lint)
       'lesshint': scope.caviar? '6.3.6': undefined,
       // Thanks to the deploy script, these next two can be devDeps instead
       // of normal dependencies:
@@ -157,7 +157,7 @@ module.exports = function getPackageJsonData(scope) {
         scope.caviar? (
           './node_modules/eslint/bin/eslint.js . --max-warnings=0 --report-unused-disable-directives && '+
           'echo \'✔  Your .js files look so good.\' && '+
-          './node_modules/@sailshq/htmlhint/bin/htmlhint -c ./.htmlhintrc views/*.ejs && ./node_modules/@sailshq/htmlhint/bin/htmlhint -c ./.htmlhintrc views/**/*.ejs && ./node_modules/@sailshq/htmlhint/bin/htmlhint -c ./.htmlhintrc views/**/**/*.ejs && ./node_modules/@sailshq/htmlhint/bin/htmlhint -c ./.htmlhintrc views/**/**/**/*.ejs && ./node_modules/@sailshq/htmlhint/bin/htmlhint -c ./.htmlhintrc views/**/**/**/**/*.ejs && ./node_modules/@sailshq/htmlhint/bin/htmlhint -c ./.htmlhintrc views/**/**/**/**/**/*.ejs && ./node_modules/@sailshq/htmlhint/bin/htmlhint -c ./.htmlhintrc views/**/**/**/**/**/**/*.ejs && '+
+          './node_modules/htmlhint/bin/htmlhint -c ./.htmlhintrc views/*.ejs && ./node_modules/htmlhint/bin/htmlhint -c ./.htmlhintrc views/**/*.ejs && ./node_modules/htmlhint/bin/htmlhint -c ./.htmlhintrc views/**/**/*.ejs && ./node_modules/htmlhint/bin/htmlhint -c ./.htmlhintrc views/**/**/**/*.ejs && ./node_modules/htmlhint/bin/htmlhint -c ./.htmlhintrc views/**/**/**/**/*.ejs && ./node_modules/htmlhint/bin/htmlhint -c ./.htmlhintrc views/**/**/**/**/**/*.ejs && ./node_modules/htmlhint/bin/htmlhint -c ./.htmlhintrc views/**/**/**/**/**/**/*.ejs && '+
           'echo \'✔  So do your .ejs files.\' && '+
           './node_modules/lesshint/bin/lesshint assets/styles/ --max-warnings=0 && '+
           'echo \'✔  Your .less files look good, too.\''

--- a/lib/core-generators/new/get-package-json-data.js
+++ b/lib/core-generators/new/get-package-json-data.js
@@ -134,7 +134,7 @@ module.exports = function getPackageJsonData(scope) {
 
       // Caviar only:
       '@sailshq/htmlhint': scope.caviar? '^0.9.16': undefined,// « FUTURE: Explore options w/ ejslint (https://www.npmjs.com/package/ejs-lint)
-      '@sailshq/lesshint': scope.caviar? '^4.6.6': undefined,
+      'lesshint': scope.caviar? '6.3.6': undefined,
       // Thanks to the deploy script, these next two can be devDeps instead
       // of normal dependencies:
       grunt: scope.caviar? GRUNT_DEP_SVR: undefined,
@@ -159,7 +159,7 @@ module.exports = function getPackageJsonData(scope) {
           'echo \'✔  Your .js files look so good.\' && '+
           './node_modules/@sailshq/htmlhint/bin/htmlhint -c ./.htmlhintrc views/*.ejs && ./node_modules/@sailshq/htmlhint/bin/htmlhint -c ./.htmlhintrc views/**/*.ejs && ./node_modules/@sailshq/htmlhint/bin/htmlhint -c ./.htmlhintrc views/**/**/*.ejs && ./node_modules/@sailshq/htmlhint/bin/htmlhint -c ./.htmlhintrc views/**/**/**/*.ejs && ./node_modules/@sailshq/htmlhint/bin/htmlhint -c ./.htmlhintrc views/**/**/**/**/*.ejs && ./node_modules/@sailshq/htmlhint/bin/htmlhint -c ./.htmlhintrc views/**/**/**/**/**/*.ejs && ./node_modules/@sailshq/htmlhint/bin/htmlhint -c ./.htmlhintrc views/**/**/**/**/**/**/*.ejs && '+
           'echo \'✔  So do your .ejs files.\' && '+
-          './node_modules/@sailshq/lesshint/bin/lesshint assets/styles/ --max-warnings=0 && '+
+          './node_modules/lesshint/bin/lesshint assets/styles/ --max-warnings=0 && '+
           'echo \'✔  Your .less files look good, too.\''
         ) : (
           './node_modules/eslint/bin/eslint.js . --max-warnings=0 --report-unused-disable-directives && '+

--- a/lib/core-generators/new/get-package-json-data.js
+++ b/lib/core-generators/new/get-package-json-data.js
@@ -57,7 +57,7 @@ module.exports = function getPackageJsonData(scope) {
     // External hooks
     'sails-hook-apianalytics': scope.caviar ? '^2.0.3' : undefined,
     'sails-hook-grunt': !scope.caviar ? SAILS_HOOK_GRUNT_DEP_SVR : undefined,//« FUTURE: potential changes here for non-caviar apps too (see https://sailsjs.com/roadmap)
-    'sails-hook-organics': scope.caviar ? '^0.15.0' : undefined,//« (formerly `sails-stdlib`)
+    'sails-hook-organics': scope.caviar ? '^0.16.0' : undefined,//« (formerly `sails-stdlib`)
     'sails-hook-orm': '^2.1.1',
     'sails-hook-sockets': '^1.5.5',
 

--- a/lib/core-generators/new/get-package-json-data.js
+++ b/lib/core-generators/new/get-package-json-data.js
@@ -36,7 +36,7 @@ module.exports = function getPackageJsonData(scope) {
   // base it off of the `version` specified in the package.json of Sails itself.
   var sailsSVR = '^' + sailsPkg.version;
 
-  var GRUNT_DEP_SVR = '1.0.1';
+  var GRUNT_DEP_SVR = '1.0.4';
   var SAILS_HOOK_GRUNT_DEP_SVR = '^3.1.0';
 
   // List default dependencies used for apps with a frontend

--- a/lib/core-generators/new/get-package-json-data.js
+++ b/lib/core-generators/new/get-package-json-data.js
@@ -130,7 +130,7 @@ module.exports = function getPackageJsonData(scope) {
     dependencies: declaredDeps,
     devDependencies: {
       // Everyone should use this:
-      '@sailshq/eslint': '^4.19.3',
+      'eslint': '5.16.0',
 
       // Caviar only:
       '@sailshq/htmlhint': scope.caviar? '^0.9.16': undefined,// « FUTURE: Explore options w/ ejslint (https://www.npmjs.com/package/ejs-lint)

--- a/lib/core-generators/new/templates/eslintrc.template
+++ b/lib/core-generators/new/templates/eslintrc.template
@@ -28,7 +28,7 @@
 
   "parserOptions": {
     "ecmaVersion": 2018
-    ^^See https://eslint.org/docs/user-guide/migrating-to-5.0.0#experimental-object-rest-spread
+    // ^^See https://eslint.org/docs/user-guide/migrating-to-5.0.0#experimental-object-rest-spread
   },
 
   "globals": {<% if (!_.contains(without,'orm')) { %>

--- a/lib/core-generators/new/templates/eslintrc.template
+++ b/lib/core-generators/new/templates/eslintrc.template
@@ -28,7 +28,6 @@
 
   "parserOptions": {
     "ecmaVersion": 2018
-    // ^^See https://eslint.org/docs/user-guide/migrating-to-5.0.0#experimental-object-rest-spread
   },
 
   "globals": {<% if (!_.contains(without,'orm')) { %>

--- a/lib/core-generators/new/templates/eslintrc.template
+++ b/lib/core-generators/new/templates/eslintrc.template
@@ -27,10 +27,8 @@
   },
 
   "parserOptions": {
-    "ecmaVersion": 8,
-    "ecmaFeatures": {
-      "experimentalObjectRestSpread": true
-    }
+    "ecmaVersion": 2018
+    ^^See https://eslint.org/docs/user-guide/migrating-to-5.0.0#experimental-object-rest-spread
   },
 
   "globals": {<% if (!_.contains(without,'orm')) { %>

--- a/lib/core-generators/new/templates/lesshintrc.template
+++ b/lib/core-generators/new/templates/lesshintrc.template
@@ -7,7 +7,7 @@
   // selector and CSS rule issues.
   // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
   // For more information about any of the rules below, check out the reference page
-  // of all rules at https://github.com/lesshint/lesshint/blob/v4.6.4/lib/linters/README.md
+  // of all rules at https://github.com/lesshint/lesshint/blob/v6.3.6/lib/linters/README.md
   // If you're unsure or could use some advice, come by https://sailsjs.com/support.
   // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
   "singleLinePerSelector": false,
@@ -41,6 +41,6 @@
   // In this case, the ampersand has a distinct meaning, and it does not refer
   // to an element.  (It's referring to the case where that class is matched at
   // the parent level, rather than talking about a descendant.)
-  // https://github.com/lesshint/lesshint/blob/v4.6.4/lib/linters/README.md#qualifyingelement
+  // https://github.com/lesshint/lesshint/blob/v6.3.6/lib/linters/README.md#qualifyingelement
   // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 }


### PR DESCRIPTION
• Switched from @sailshq/eslint back to eslint, and upgraded to v5.16.0
• Updated .eslintrc so that it doesn't show a deprecation message about `experimentalObjectRestSpread`
• Switched from @sailshq/lesshint back to lesshint, and upgraded to v6.3.6
• Switched from @sailshq/htmlhint back to htmlhint, and upgraded to v0.11.0
• Updated sails-hook-organics to v0.16.0 to take advantage of fixes to resolve vulnerability/deprecation warnings