### PR TITLE
Changed language of description for toName in send-template-email.js.…

### DIFF
--- a/lib/core-generators/new/templates/api/helpers/send-template-email.js.template
+++ b/lib/core-generators/new/templates/api/helpers/send-template-email.js.template
@@ -51,7 +51,7 @@ module.exports = {
     },
 
     toName: {
-      description: 'Full name of the primary recipient.',
+      description: 'Name of the primary recipient as displayed in their inbox.',
       example: 'Nola Thacker',
     },
 


### PR DESCRIPTION
"Full name" only applies to cases in which `fullName` is being used. New language is agnostic to different methods for storing a user's name.