### PR TITLE
Update file paths referenced in "How do I disable Stripe" of FAQ

### DIFF
--- a/lib/core-generators/new/templates/views/pages/faq.ejs
+++ b/lib/core-generators/new/templates/views/pages/faq.ejs
@@ -123,11 +123,11 @@
         </li>
         <li>Remove the update billing card endpoint and all references to it by doing the following:
           <ul>
-            <li>Delete the file at <code>api/account/update-billing-card.js</code>.</li>
+            <li>Delete the file at <code>api/controllers/account/update-billing-card.js</code>.</li>
             <li>In <code>config/routes.js</code>, delete the route configuration for <code>'PUT /api/v1/account/update-billing-card'</code>.</li>
             <li>In <code>assets/js/cloud.setup.js</code>, delete the <code>updateBillingCard</code> method.</li>
-            <li>In <code>assets/js/pages/account/my-account.page.js</code>, remove the <code>clickStripeCheckoutButton</code> method.</li>
-            <li>In <code>views/pages/account/my-account.ejs</code>, remove the HTML related to billing.</li>
+            <li>In <code>assets/js/pages/account/account-overview.page.js</code>, remove the <code>clickStripeCheckoutButton</code> method.</li>
+            <li>In <code>views/pages/account/account-overview.ejs</code>, remove the HTML related to billing.</li>
           </ul>
         </li>
         <li>In <code>api/hooks/custom/index.js</code>, remove the warnings related to Stripe.</li>


### PR DESCRIPTION
After generating a new web app via `sails new`, the page at `/faq` describes how one might remove the Stripe integration.

However, some of the file paths mentioned are out of date.


| Referenced Location|Actual Location|
|---|---|
|api/account/update-billing-card.js|api/controllers/account/update-billing-card.js|
|assets/js/pages/account/my-account.page.js|assets/js/pages/account/account-overview.page.js|
|views/pages/account/my-account.ejs|views/pages/account/account-overview.ejs|

<br>

![PixelSnap 2020-06-14 at 13 59 25@2x](https://user-images.githubusercontent.com/6632454/84592838-bffb0980-ae48-11ea-8fb5-68373bb71509.png)

