### PR TITLE
Add regex validation support to ajax-form component

### DIFF
--- a/lib/core-generators/new/templates/assets/js/components/ajax-form.component.js
+++ b/lib/core-generators/new/templates/assets/js/components/ajax-form.component.js
@@ -94,7 +94,7 @@ parasails.registerComponent('ajaxForm', {
     if (this.formRules) {
       var SUPPORTED_RULES = [
         'required', 'isEmail', 'isIn', 'is', 'minLength', 'maxLength',
-        'sameAs', 'isHalfwayDecentPassword', 'custom'
+        'sameAs', 'isHalfwayDecentPassword', 'regex', 'custom'
       ];
       for (let fieldName in this.formRules) {
         for (let ruleName in this.formRules[fieldName]) {
@@ -273,6 +273,11 @@ parasails.registerComponent('ajaxForm', {
                   fieldValue.length < 6
                 );
               }
+            } else if (ruleName === 'regex') {
+            // ® Must match the regex specified
+            violation = (
+              !ruleRhs.test(fieldValue)
+            );
             } else if (ruleName === 'custom' && _.isFunction(ruleRhs)) {
               // ® Provided function must return truthy when invoked with the value.
               try {


### PR DESCRIPTION
Regex support for ajax form, as proposed here: https://github.com/mikermcneil/hydroplane/pull/2/commits/f69cb214883e1b189604d2033721bf05cdbdec48