### PR TITLE
Update versions of packages in `get-package-json-data.js`

### DIFF
--- a/lib/core-generators/new/get-package-json-data.js
+++ b/lib/core-generators/new/get-package-json-data.js
@@ -103,7 +103,6 @@ module.exports = function getPackageJsonData(scope) {
     delete declaredDeps.grunt;
   }//>-
 
-
   // If this is an app being generated with `--no-frontend`, then include only
   // the bare minimum, esp. excluding grunt and all grunt-related dependencies.
   if (scope.frontend === false) {

--- a/lib/core-generators/new/get-package-json-data.js
+++ b/lib/core-generators/new/get-package-json-data.js
@@ -103,6 +103,7 @@ module.exports = function getPackageJsonData(scope) {
     delete declaredDeps.grunt;
   }//>-
 
+
   // If this is an app being generated with `--no-frontend`, then include only
   // the bare minimum, esp. excluding grunt and all grunt-related dependencies.
   if (scope.frontend === false) {

--- a/lib/core-generators/new/get-package-json-data.js
+++ b/lib/core-generators/new/get-package-json-data.js
@@ -55,10 +55,10 @@ module.exports = function getPackageJsonData(scope) {
     'grunt': !scope.caviar ? GRUNT_DEP_SVR : undefined,
 
     // External hooks
-    'sails-hook-apianalytics': scope.caviar ? '^2.0.3' : undefined,
+    'sails-hook-apianalytics': scope.caviar ? '^2.0.6' : undefined,
     'sails-hook-grunt': !scope.caviar ? SAILS_HOOK_GRUNT_DEP_SVR : undefined,//« FUTURE: potential changes here for non-caviar apps too (see https://sailsjs.com/roadmap)
-    'sails-hook-organics': scope.caviar ? '^2.2.0' : undefined,//« (formerly `sails-stdlib`)
-    'sails-hook-orm': '^4.0.0',
+    'sails-hook-organics': scope.caviar ? '^2.2.2' : undefined,//« (formerly `sails-stdlib`)
+    'sails-hook-orm': '^4.0.3',
     'sails-hook-sockets': '^3.0.0',
 
     // Production stuff
@@ -66,10 +66,10 @@ module.exports = function getPackageJsonData(scope) {
     '@sailshq/socket.io-redis': '^6.1.2',
 
     // Lodash
-    '@sailshq/lodash': scope.lodashSVR || '^3.10.3',
+    '@sailshq/lodash': scope.lodashSVR || '^3.10.6',
 
     // Async
-    'async': scope.asyncSVR || '2.0.1'
+    'async': scope.asyncSVR || '2.6.4'
 
   };
 


### PR DESCRIPTION
Changes:
- Updated versions used in generated `package.json` files in new Sails apps.
   - sails-hook-apianalytics: `^2.0.3` » `^2.0.6`
   - sails-hook-organics: `^2.2.0` » `^2.2.2`
   - sails-hook-orm: `^4.0.0` » `^4.0.3`
   - @sailshq/lodash: `^3.10.3` » `^3.10.6`
   - async: `2.0.1` » `2.6.4`