### PR TITLE
Update custom hook template to set locals for head requests

### DIFF
--- a/lib/core-generators/new/templates/api/hooks/custom/index.js.template
+++ b/lib/core-generators/new/templates/api/hooks/custom/index.js.template
@@ -108,9 +108,9 @@ will be disabled and/or hidden in the UI.
 
             var url = require('url');
 
-            // First, if this is a GET request (and thus potentially a view),
+            // First, if this is a GET or HEAD request (and thus potentially a view),
             // attach a couple of guaranteed locals.
-            if (req.method === 'GET') {
+            if (req.method === 'GET' || req.method === 'HEAD') {
 
               // The  `_environment` local lets us do a little workaround to make Vue.js
               // run in "production mode" without unnecessarily involving complexities


### PR DESCRIPTION
Changes:
- Updated the custom hook template to set `res.locals` for HEAD requests.

Previously, before this change, you end up with HEAD requests (from bots perhaps, eg. Algolia crawler) -- but if the page references guaranteed locals, then you end up trying to reference e.g. `me` without having access to it.  This change makes it so you have access to it.