### PR TITLE
Bump sails-hook-organics to latest version and update sendTemplateEmail helper

### DIFF
--- a/lib/core-generators/new/get-package-json-data.js
+++ b/lib/core-generators/new/get-package-json-data.js
@@ -57,7 +57,7 @@ module.exports = function getPackageJsonData(scope) {
     // External hooks
     'sails-hook-apianalytics': scope.caviar ? '^2.0.6' : undefined,
     'sails-hook-grunt': !scope.caviar ? SAILS_HOOK_GRUNT_DEP_SVR : undefined,//« FUTURE: potential changes here for non-caviar apps too (see https://sailsjs.com/roadmap)
-    'sails-hook-organics': scope.caviar ? '^2.2.2' : undefined,//« (formerly `sails-stdlib`)
+    'sails-hook-organics': scope.caviar ? '^3.0.0' : undefined,//« (formerly `sails-stdlib`)
     'sails-hook-orm': '^4.0.3',
     'sails-hook-sockets': '^3.0.0',
 

--- a/lib/core-generators/new/templates/api/helpers/send-template-email.js.template
+++ b/lib/core-generators/new/templates/api/helpers/send-template-email.js.template
@@ -55,6 +55,18 @@ module.exports = {
       example: 'Nola Thacker',
     },
 
+    replyTo: {
+      description: 'The reply to email address and name.',
+      example: {
+        emailAddress: 'anne.m.martin@example.com',
+        name: 'Anne M. Martin'
+      },
+      type: {
+        emailAddress: 'string',
+        name: 'string',
+      }
+    },
+
     subject: {
       description: 'The subject of the email.',
       example: 'Hello there.',
@@ -246,6 +258,7 @@ module.exports = {
         subject: subjectLinePrefix+subject,
         from: from,
         fromName: fromName,
+        replyTo: replyTo,
         attachments
       };
 


### PR DESCRIPTION
Changes:
- Added `replyTo` email address support to the sendTemplateEmail helper
- updated the version of sails-hook-organics that is used in the generated package.json in new Sails apps