### PR TITLE
Add assosiations type to model generator

### DIFF
--- a/lib/core-generators/model/templates/attribute.template
+++ b/lib/core-generators/model/templates/attribute.template
@@ -14,7 +14,7 @@
     if(type.includes(['[',']')) { 
     type = type.replace('[','').replace(']','').toLowerCase();
   %>
-    <% if(type[type.length-1] == 's') { %>collection:<% } else { %>model:<% } %> '<%= type %>'
+    <% if(name[name.length-1] == 's') { %>collection:<% } else { %>model:<% } %> '<%= type %>'
   <% } else { %>
     type: '<%= type %>'
   <% } %>
@@ -24,7 +24,7 @@
     if(type.includes(['[',']')) {
     type = type.replace('[','').replace(']','').toLowerCase();
 %>
-    <% if(type[type.length-1] == 's') { %>collection:<% } else { %>model:<% } %> '<%= type %>'
+    <% if(name[name.length-1] == 's') { %>collection:<% } else { %>model:<% } %> '<%= type %>'
   <% } else { %>
     type: '<%= type %>'
   <% } %>

--- a/lib/core-generators/model/templates/attribute.template
+++ b/lib/core-generators/model/templates/attribute.template
@@ -8,7 +8,14 @@
  *
  */
 %>
-<%if (lang === 'js') {%>    <%= name %>: { type: '<%= type %>' }
+<% if (lang === 'js') { %>
+<%= name %>: { 
+  <% if(type.includes(['[',']')) { %>
+  collection: '<%= type.replace('[','').replace(']','').toLowerCase() %>'
+  <% } else { %>
+  type: '<%= type %>'
+  <% } %>
+}
 <%} else if (lang === 'coffee'){ %>    <%=name%>:
     type: '<%= type %>'
 <%}%>

--- a/lib/core-generators/model/templates/attribute.template
+++ b/lib/core-generators/model/templates/attribute.template
@@ -10,15 +10,21 @@
 %>
 <% if (lang === 'js') { %>
   <%= name %>: { 
-  <% if(type.includes(['[',']')) { %>
-    collection: '<%= type.replace('[','').replace(']','').toLowerCase() %>'
+  <%
+    if(type.includes(['[',']')) { 
+    type = type.replace('[','').replace(']','').toLowerCase();
+  %>
+    <% if(type[type.length-1] == 's') { %>collection:<% } else { %>model:<% } %> '<%= type %>'
   <% } else { %>
     type: '<%= type %>'
   <% } %>
 }
 <%} else if (lang === 'coffee'){ %>    <%=name%>:
-<% if(type.includes(['[',']')) { %>
-    collection: '<%= type.replace('[','').replace(']','').toLowerCase() %>'
+<% 
+    if(type.includes(['[',']')) {
+    type = type.replace('[','').replace(']','').toLowerCase();
+%>
+    <% if(type[type.length-1] == 's') { %>collection:<% } else { %>model:<% } %> '<%= type %>'
   <% } else { %>
     type: '<%= type %>'
   <% } %>

--- a/lib/core-generators/model/templates/attribute.template
+++ b/lib/core-generators/model/templates/attribute.template
@@ -9,13 +9,17 @@
  */
 %>
 <% if (lang === 'js') { %>
-<%= name %>: { 
+  <%= name %>: { 
   <% if(type.includes(['[',']')) { %>
-  collection: '<%= type.replace('[','').replace(']','').toLowerCase() %>'
+    collection: '<%= type.replace('[','').replace(']','').toLowerCase() %>'
   <% } else { %>
-  type: '<%= type %>'
+    type: '<%= type %>'
   <% } %>
 }
 <%} else if (lang === 'coffee'){ %>    <%=name%>:
+<% if(type.includes(['[',']')) { %>
+    collection: '<%= type.replace('[','').replace(']','').toLowerCase() %>'
+  <% } else { %>
     type: '<%= type %>'
+  <% } %>
 <%}%>


### PR DESCRIPTION
Until now it was `sails generate model Cart user:string` And no way to pass assosiations.
Now you can put the assosiated object in array brackets and it generates model with assosiations.
New way:
`sails generate model Cart user:[User]`
and it will generate
```
user: {
model: 'user'
}
```

`sails generate model Cart users:[User]`
and it will generate
```
user: {
collection: 'user'
}
```